### PR TITLE
Add Prima sets

### DIFF
--- a/Prima/001_Bulbasaur.yaml
+++ b/Prima/001_Bulbasaur.yaml
@@ -1,0 +1,18 @@
+species: Bulbasaur
+setname: Prima
+item: [null]
+ability: [Qvergrow]
+moves:
+    - [Razor leaf]
+    - [Leech seed]
+    - [Sleep Powder]
+    - [Sweet Scent]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/002_Ivysaur.yaml
+++ b/Prima/002_Ivysaur.yaml
@@ -1,0 +1,18 @@
+species: Ivysaur
+setname: Prima
+item: [null]
+ability: [Overgrow]
+moves:
+    - [Sweet Scent]
+    - [Double-Edge]
+    - [Solar Beam]
+    - [Bullet Seed]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/003_Venusaur.yaml
+++ b/Prima/003_Venusaur.yaml
@@ -1,0 +1,18 @@
+species: Venusaur
+setname: Prima
+item: [null]
+ability: [Overgrow]
+moves:
+    - [Sweet Scent]
+    - [Synthesis]
+    - [Solarbeam]
+    - [Leech Seed]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/004_Charmander.yaml
+++ b/Prima/004_Charmander.yaml
@@ -1,0 +1,18 @@
+species: Charmander
+setname: Prima
+item: [null]
+ability: [Blaze]
+moves:
+    - [SmokeScreen]
+    - [Scratch]
+    - [Dragon Rage]
+    - [Fire fang]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/005_Charmeleon.yaml
+++ b/Prima/005_Charmeleon.yaml
@@ -1,0 +1,18 @@
+species: Charmeleon
+setname: Prima
+item: [null]
+ability: [Blaze]
+moves:
+    - [Slash]
+    - [Scary Face]
+    - [Fire Fang]
+    - [Dragon Rage]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/006_Charizard.yaml
+++ b/Prima/006_Charizard.yaml
@@ -1,0 +1,18 @@
+species: Charizard
+setname: Prima
+item: [null]
+ability: [Blaze]
+moves:
+    - [Flamethrower]
+    - [Wing Attack]
+    - [Heat Wave]
+    - [Flare Blitz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/007_Squirtle.yaml
+++ b/Prima/007_Squirtle.yaml
@@ -1,0 +1,18 @@
+species: Squirtle
+setname: Prima
+item: [null]
+ability: [Torrent]
+moves:
+    - [Withdraw]
+    - [Mud Sport]
+    - [Protect]
+    - [Skull Bash]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/008_Wartortle.yaml
+++ b/Prima/008_Wartortle.yaml
@@ -1,0 +1,18 @@
+species: Wartortle
+setname: Prima
+item: [null]
+ability: [Torrent]
+moves:
+    - [Withdraw]
+    - [Rain Dance]
+    - [Protect]
+    - [Skull Bash]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/009_Blastoise.yaml
+++ b/Prima/009_Blastoise.yaml
@@ -1,0 +1,18 @@
+species: Blastoise
+setname: Prima
+item: [null]
+ability: [Torrent]
+moves:
+    - [Hydro Pump]
+    - [Withdraw]
+    - [Hydro Cannon]
+    - [Skull Bash]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/010_Caterpie.yaml
+++ b/Prima/010_Caterpie.yaml
@@ -1,0 +1,16 @@
+species: Caterpie
+setname: Prima
+item: [null]
+ability: [Shield Dust]
+moves:
+    - [String Shot]
+    - [Tackle]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/011_Metapod.yaml
+++ b/Prima/011_Metapod.yaml
@@ -1,0 +1,15 @@
+species: Metapod
+setname: Prima
+item: [null]
+ability: [Shed Skin]
+moves:
+    - [Harden]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/012_Butterfree.yaml
+++ b/Prima/012_Butterfree.yaml
@@ -1,0 +1,18 @@
+species: Butterfree
+setname: Prima
+item: [null]
+ability: [Compoundeyes]
+moves:
+    - [Giga Drain]
+    - [Silver Wind]
+    - [Aerial Ace]
+    - [Bug Buzz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/013_Weedle.yaml
+++ b/Prima/013_Weedle.yaml
@@ -1,0 +1,16 @@
+species: Weedle
+setname: Prima
+item: [null]
+ability: [Shield Dust]
+moves:
+    - [String Shot]
+    - [Poison Sting]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/014_Kakuna.yaml
+++ b/Prima/014_Kakuna.yaml
@@ -1,0 +1,15 @@
+species: Kakuna
+setname: Prima
+item: [null]
+ability: [Shed Skin]
+moves:
+    - [Harden]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/015_Beedrill.yaml
+++ b/Prima/015_Beedrill.yaml
@@ -1,0 +1,18 @@
+species: Beedrill
+setname: Prima
+item: [null]
+ability: [Swarm]
+moves:
+    - [Endeavor]
+    - [X-Scissor]
+    - [Poison Jab]
+    - [U-turn]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/016_Pidgey.yaml
+++ b/Prima/016_Pidgey.yaml
@@ -1,0 +1,18 @@
+species: Pidgey
+setname: Prima
+item: [null]
+ability: [Keen Eye,Tangled Feet]
+moves:
+    - [Air Slash]
+    - [Secret Power]
+    - [Whirlwind]
+    - [Brave Bird]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/017_Pidgeotto.yaml
+++ b/Prima/017_Pidgeotto.yaml
@@ -1,0 +1,18 @@
+species: Pidgeotto
+setname: Prima
+item: [null]
+ability: [Keen eye,Tangled Feet]
+moves:
+    - [Air Slash]
+    - [Sand Attack]
+    - [Fly]
+    - [Roost]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/018_Pidgeot.yaml
+++ b/Prima/018_Pidgeot.yaml
@@ -1,0 +1,18 @@
+species: Pidgeot
+setname: Prima
+item: [null]
+ability: [Keen eye,Tangled feet]
+moves:
+    - [Air Slash]
+    - [Tailwind]
+    - [Mirror Move]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/019_Rattata.yaml
+++ b/Prima/019_Rattata.yaml
@@ -1,0 +1,18 @@
+species: Rattata
+setname: Prima
+item: [null]
+ability: [Run away,Guts]
+moves:
+    - [Bite]
+    - [Super Gang]
+    - [Reversal]
+    - [Quick Attack]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/020_Raticate.yaml
+++ b/Prima/020_Raticate.yaml
@@ -1,0 +1,18 @@
+species: Raticate
+setname: Prima
+item: [null]
+ability: [Run away,Guts]
+moves:
+    - [Crunch]
+    - [Double-edge]
+    - [Hyper Fang]
+    - [Sucker Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/021_Spearow.yaml
+++ b/Prima/021_Spearow.yaml
@@ -1,0 +1,18 @@
+species: Spearow
+setname: Prima
+item: [null]
+ability: [Keen Eye]
+moves:
+    - [Sky Attack]
+    - [Drill Peck]
+    - [Roost]
+    - [Secret Power]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/022_Fearow.yaml
+++ b/Prima/022_Fearow.yaml
@@ -1,0 +1,18 @@
+species: Fearow
+setname: Prima
+item: [null]
+ability: [Keen Eye]
+moves:
+    - [Giga Impact]
+    - [Assurance]
+    - [Drill Peck]
+    - [Roost]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/023_Ekans.yaml
+++ b/Prima/023_Ekans.yaml
@@ -1,0 +1,18 @@
+species: Ekans
+setname: Prima
+item: [null]
+ability: [Intimidate,Shed Skin]
+moves:
+    - [Gastro Acid]
+    - [Dig]
+    - [Toxic]
+    - [Poison Fang]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/024_Arbok.yaml
+++ b/Prima/024_Arbok.yaml
@@ -1,0 +1,18 @@
+species: Arbok
+setname: Prima
+item: [null]
+ability: [Intimidate,Shed Skin]
+moves:
+    - [Gunk Shot]
+    - [Poison jab]
+    - [Toxic]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/025_Pikachu.yaml
+++ b/Prima/025_Pikachu.yaml
@@ -1,0 +1,18 @@
+species: Pikachu
+setname: Prima
+item: [null]
+ability: [Static]
+moves:
+    - [Iron Tail]
+    - [Thunder]
+    - [Charge Beam]
+    - [Discharge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/026_Raichu.yaml
+++ b/Prima/026_Raichu.yaml
@@ -1,0 +1,18 @@
+species: Raichu
+setname: Prima
+item: [null]
+ability: [Static]
+moves:
+    - [Iron Tail]
+    - [Thunderbolt]
+    - [Thunder]
+    - [Charge Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/027_Sandshrew.yaml
+++ b/Prima/027_Sandshrew.yaml
@@ -1,0 +1,18 @@
+species: Sandshrew
+setname: Prima
+item: [null]
+ability: [Sand Veil]
+moves:
+    - [Slash]
+    - [Sandstorm]
+    - [Sand Tomb]
+    - [Crush Claw]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/028_Sandslash.yaml
+++ b/Prima/028_Sandslash.yaml
@@ -1,0 +1,18 @@
+species: Sandslash
+setname: Prima
+item: [null]
+ability: [Sand Veil]
+moves:
+    - [Dig]
+    - [Slash]
+    - [Gyro Ball]
+    - [Sand Tomb]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/029_Nidoran-F.yaml
+++ b/Prima/029_Nidoran-F.yaml
@@ -1,0 +1,18 @@
+species: Nidoran-F
+setname: Prima
+item: [null]
+ability: [Poison Point,Rivalry]
+moves:
+    - [Thunder]
+    - [Poison Fang]
+    - [Toxic Spikes]
+    - [Double Kick]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/030_Nidorina.yaml
+++ b/Prima/030_Nidorina.yaml
@@ -1,0 +1,18 @@
+species: Nidorina
+setname: Prima
+item: [null]
+ability: [Poison Point,Rivalry]
+moves:
+    - [Crunch]
+    - [Thunder]
+    - [Poison Fang]
+    - [Toxic Spikes]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/031_Nidoqueen.yaml
+++ b/Prima/031_Nidoqueen.yaml
@@ -1,0 +1,18 @@
+species: Nidoqueen
+setname: Prima
+item: [null]
+ability: [Poison Point,Rivalry]
+moves:
+    - [Dig]
+    - [Earth Power]
+    - [Poison Jab]
+    - [Roar]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/032_Nidoran-M.yaml
+++ b/Prima/032_Nidoran-M.yaml
@@ -1,0 +1,18 @@
+species: Nidoran-M
+setname: Prima
+item: [null]
+ability: [Poison Point,Rivalry]
+moves:
+    - [Horn Attack]
+    - [Horn Drill]
+    - [Poison Jab]
+    - [Toxic Spikes]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/033_Nidorino.yaml
+++ b/Prima/033_Nidorino.yaml
@@ -1,0 +1,18 @@
+species: Nidorino
+setname: Prima
+item: [null]
+ability: [Poison Point,Rivalry]
+moves:
+    - [Horn Drill]
+    - [Poison Jab]
+    - [Toxic Spikes]
+    - [Sludge Bomb]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/034_Nidoking.yaml
+++ b/Prima/034_Nidoking.yaml
@@ -1,0 +1,18 @@
+species: Nidoking
+setname: Prima
+item: [null]
+ability: [Poison Point,Rivalry]
+moves:
+    - [Thrash]
+    - [Earth Power]
+    - [Roar]
+    - [Mega Horn]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/035_Clefairy.yaml
+++ b/Prima/035_Clefairy.yaml
@@ -1,0 +1,18 @@
+species: Clefairy
+setname: Prima
+item: [null]
+ability: [Cute Charm,Magic Guard]
+moves:
+    - [Healing Wish]
+    - [Follow Me]
+    - [Wake-up Slap]
+    - [Metronome]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/036_Clefable.yaml
+++ b/Prima/036_Clefable.yaml
@@ -1,0 +1,18 @@
+species: Clefable
+setname: Prima
+item: [null]
+ability: [Cute Charm,Magic Guard]
+moves:
+    - [Focus Blast]
+    - [Sing]
+    - [Fire Blast]
+    - [Metronome]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/037_Vulpix.yaml
+++ b/Prima/037_Vulpix.yaml
@@ -1,0 +1,18 @@
+species: Vulpix
+setname: Prima
+item: [null]
+ability: [Flash Fire]
+moves:
+    - [Flamethrower]
+    - [Extrasensory]
+    - [Fire Blast]
+    - [Quick Attack]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/038_Ninetales.yaml
+++ b/Prima/038_Ninetales.yaml
@@ -1,0 +1,18 @@
+species: Ninetales
+setname: Prima
+item: [null]
+ability: [Flash Fire]
+moves:
+    - [Will-O-Wisp]
+    - [Fire Blast]
+    - [Overheat]
+    - [Safeguard]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/039_Jigglypuff.yaml
+++ b/Prima/039_Jigglypuff.yaml
@@ -1,0 +1,18 @@
+species: Jigglypuff
+setname: Prima
+item: [null]
+ability: [Cute Charm]
+moves:
+    - [Double-Edge]
+    - [Body Slam]
+    - [Wake-Up Slap]
+    - [Mimic]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/040_Wigglytuff.yaml
+++ b/Prima/040_Wigglytuff.yaml
@@ -1,0 +1,18 @@
+species: Wigglytuff
+setname: Prima
+item: [null]
+ability: [Cute Charm]
+moves:
+    - [DoubleSlap]
+    - [Gyro ball]
+    - [Charge Beam]
+    - [Focus Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/041_Zubat.yaml
+++ b/Prima/041_Zubat.yaml
@@ -1,0 +1,18 @@
+species: Zubat
+setname: Prima
+item: [null]
+ability: [Inner Focus]
+moves:
+    - [Air Slash]
+    - [Wing Attack]
+    - [Poison Fang]
+    - [Brave Bird]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/042_Golbat.yaml
+++ b/Prima/042_Golbat.yaml
@@ -1,0 +1,18 @@
+species: Golbat
+setname: Prima
+item: [null]
+ability: [Inner Focus]
+moves:
+    - [Air Slash]
+    - [Giga Impact]
+    - [Fly]
+    - [Poison Fang]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/043_Oddish.yaml
+++ b/Prima/043_Oddish.yaml
@@ -1,0 +1,18 @@
+species: Oddish
+setname: Prima
+item: [null]
+ability: [Chlorophyll]
+moves:
+    - [Giga Drain]
+    - [Poison Powder]
+    - [Sleep Powder]
+    - [Petal Dance]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/044_Gloom.yaml
+++ b/Prima/044_Gloom.yaml
@@ -1,0 +1,18 @@
+species: Gloom
+setname: Prima
+item: [null]
+ability: [Chlorophyll]
+moves:
+    - [Sweet Scent]
+    - [Giga Drain]
+    - [Moonlight]
+    - [Petal Dance]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/045_Vileplume.yaml
+++ b/Prima/045_Vileplume.yaml
@@ -1,0 +1,18 @@
+species: Vileplume
+setname: Prima
+item: [null]
+ability: [Chlorophyll]
+moves:
+    - [Giga Drain]
+    - [Stun Spore]
+    - [Poison Powder]
+    - [SolarBeam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/046_Paras.yaml
+++ b/Prima/046_Paras.yaml
@@ -1,0 +1,18 @@
+species: Paras
+setname: Prima
+item: [null]
+ability: [Effect Spore,Dry Skin]
+moves:
+    - [Giga Drain]
+    - [Spore]
+    - [X-Scissor]
+    - [Poison Powder]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/047_Parasect.yaml
+++ b/Prima/047_Parasect.yaml
@@ -1,0 +1,18 @@
+species: Parasect
+setname: Prima
+item: [null]
+ability: [Effect Spore,Dry Skin]
+moves:
+    - [Aromatherapy]
+    - [Giga Drain]
+    - [Spore]
+    - [X-Scissor]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/048_Venonat.yaml
+++ b/Prima/048_Venonat.yaml
@@ -1,0 +1,18 @@
+species: Venonat
+setname: Prima
+item: [null]
+ability: [Compound Eyes,Tinted Lens]
+moves:
+    - [Psychic]
+    - [Signal beam]
+    - [Poison Fang]
+    - [Sleep Powder]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/049_Venomoth.yaml
+++ b/Prima/049_Venomoth.yaml
@@ -1,0 +1,18 @@
+species: Venomoth
+setname: Prima
+item: [null]
+ability: [Compound Eyes,Tinted Lens]
+moves:
+    - [Psychic]
+    - [Signal Beam]
+    - [Poison Fang]
+    - [Bug Buzz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/050_Diglett.yaml
+++ b/Prima/050_Diglett.yaml
@@ -1,0 +1,18 @@
+species: Diglett
+setname: Prima
+item: [null]
+ability: [Sand Veil,Arena Trap]
+moves:
+    - [Dig]
+    - [Earthquake]
+    - [Fissure]
+    - [Sandstorm]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/051_Dugtrio.yaml
+++ b/Prima/051_Dugtrio.yaml
@@ -1,0 +1,18 @@
+species: Dugtrio
+setname: Prima
+item: [null]
+ability: [Sand Veil,Arena Trap]
+moves:
+    - [Stone Edge]
+    - [Dig]
+    - [Earthquake]
+    - [Fissure]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/052_Meowth.yaml
+++ b/Prima/052_Meowth.yaml
@@ -1,0 +1,18 @@
+species: Meowth
+setname: Prima
+item: [null]
+ability: [Pick Up, Technician]
+moves:
+    - [Feint Attack]
+    - [Last Resort]
+    - [Fake Out]
+    - [Pay Day]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/053_Persian.yaml
+++ b/Prima/053_Persian.yaml
@@ -1,0 +1,18 @@
+species: Persian
+setname: Prima
+item: [null]
+ability: [Pick Up, Technician]
+moves:
+    - [Fake Out]
+    - [Night Slash]
+    - [Shadow Claw]
+    - [Power Gem]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/054_Psyduck.yaml
+++ b/Prima/054_Psyduck.yaml
@@ -1,0 +1,18 @@
+species: Psyduck
+setname: Prima
+item: [null]
+ability: [Damp,Cloud Nine]
+moves:
+    - [Amnesia]
+    - [Cross Chop]
+    - [Hydro Pump]
+    - [Water Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/055_Golduck.yaml
+++ b/Prima/055_Golduck.yaml
@@ -1,0 +1,18 @@
+species: Golduck
+setname: Prima
+item: [null]
+ability: [Damp,Cloud Nine]
+moves:
+    - [Hydro Pump]
+    - [Zen Headbutt]
+    - [Psychic]
+    - [Water Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/056_Mankey.yaml
+++ b/Prima/056_Mankey.yaml
@@ -1,0 +1,18 @@
+species: Mankey
+setname: Prima
+item: [null]
+ability: [Vital Spirit,Anger Point]
+moves:
+    - [Thrash]
+    - [Close Combat]
+    - [Focus Punch]
+    - [Seismic Toss]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/057_Primeape.yaml
+++ b/Prima/057_Primeape.yaml
@@ -1,0 +1,18 @@
+species: Primeape
+setname: Prima
+item: [null]
+ability: [Vital Spirit,Anger Point]
+moves:
+    - [Thrash]
+    - [Close Combat]
+    - [Focus Punch]
+    - [Cross Chop]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/058_Growlithe.yaml
+++ b/Prima/058_Growlithe.yaml
@@ -1,0 +1,18 @@
+species: Growlithe
+setname: Prima
+item: [null]
+ability: [Intimidate,Flash Fire]
+moves:
+    - [Flamethrower]
+    - [Crunch]
+    - [Heat Wave]
+    - [Flare Blitz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/059_Arcanine.yaml
+++ b/Prima/059_Arcanine.yaml
@@ -1,0 +1,18 @@
+species: Arcanine
+setname: Prima
+item: [null]
+ability: [Intimidate,Flash Fire]
+moves:
+    - [Bite]
+    - [Thunder Fang]
+    - [Extreme Speed]
+    - [Fire Fang]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/060_Poliwag.yaml
+++ b/Prima/060_Poliwag.yaml
@@ -1,0 +1,18 @@
+species: Poliwag
+setname: Prima
+item: [null]
+ability: [Water Absorb, Damp]
+moves:
+    - [Mud Shot]
+    - [Hydro Pump]
+    - [Bubble Beam]
+    - [Water Gun]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/061_Poliwhirl.yaml
+++ b/Prima/061_Poliwhirl.yaml
@@ -1,0 +1,18 @@
+species: Poliwhirl
+setname: Prima
+item: [null]
+ability: [Water Absorb, Damp]
+moves:
+    - [Belly Drum]
+    - [Mud bomb]
+    - [Hydro Pump]
+    - [Body Slam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/062_Poliwrath.yaml
+++ b/Prima/062_Poliwrath.yaml
@@ -1,0 +1,18 @@
+species: Poliwrath
+setname: Prima
+item: [null]
+ability: [Water Absorb, Damp]
+moves:
+    - [Submission]
+    - [Mind Reader]
+    - [Hypnosis]
+    - [Dynamic Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/063_Abra.yaml
+++ b/Prima/063_Abra.yaml
@@ -1,0 +1,18 @@
+species: Abra
+setname: Prima
+item: [null]
+ability: [Synchronize,Innner Focus]
+moves:
+    - [Psychic]
+    - [Skill Swap]
+    - [Dream Eater]
+    - [Reflect]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/064_Kadabra.yaml
+++ b/Prima/064_Kadabra.yaml
@@ -1,0 +1,18 @@
+species: Kadabra
+setname: Prima
+item: [null]
+ability: [Synchronize,Innner Focus]
+moves:
+    - [Miracle Eye]
+    - [Psychic]
+    - [Future Sight]
+    - [Shadow Ball]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/065_Alakazam.yaml
+++ b/Prima/065_Alakazam.yaml
@@ -1,0 +1,18 @@
+species: Alakazam
+setname: Prima
+item: [null]
+ability: [Synchronize,Innner Focus]
+moves:
+    - [Recover]
+    - [Psychic]
+    - [Kinesis]
+    - [Future Sight]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/066_Machop.yaml
+++ b/Prima/066_Machop.yaml
@@ -1,0 +1,18 @@
+species: Machop
+setname: Prima
+item: [null]
+ability: [Guts,No Guard]
+moves:
+    - [Cross Chop]
+    - [Seismic Toss]
+    - [Leer]
+    - [Fire Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/067_Machoke.yaml
+++ b/Prima/067_Machoke.yaml
@@ -1,0 +1,18 @@
+species: Machoke
+setname: Prima
+item: [null]
+ability: [Guts,No Guard]
+moves:
+    - [Submission]
+    - [Rest]
+    - [DynamicPunch]
+    - [Wake-Up Slap]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/068_Machamp.yaml
+++ b/Prima/068_Machamp.yaml
@@ -1,0 +1,18 @@
+species: Machamp
+setname: Prima
+item: [null]
+ability: [Guts,No Guard]
+moves:
+    - [Focus Punch]
+    - [Cross Chop]
+    - [DynamicPunch]
+    - [Revenge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/069_Bellsprout.yaml
+++ b/Prima/069_Bellsprout.yaml
@@ -1,0 +1,18 @@
+species: Bellsprout
+setname: Prima
+item: [null]
+ability: [Chlorophyll]
+moves:
+    - [Gastro Acid]
+    - [Wring Out]
+    - [Razor Leaf]
+    - [Sleep Powder]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/070_Weepinbell.yaml
+++ b/Prima/070_Weepinbell.yaml
@@ -1,0 +1,18 @@
+species: Weepinbell
+setname: Prima
+item: [null]
+ability: [Chlorophyll]
+moves:
+    - [Wring Out]
+    - [SolarBeam]
+    - [Slam]
+    - [Razor Leaf]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/071_Victreebel.yaml
+++ b/Prima/071_Victreebel.yaml
@@ -1,0 +1,18 @@
+species: Victreebel
+setname: Prima
+item: [null]
+ability: [Chlorophyll]
+moves:
+    - [Sweet Scent]
+    - [Solar Beam]
+    - [Sleep Powder]
+    - [Leaf Storm]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/072_Tentacool.yaml
+++ b/Prima/072_Tentacool.yaml
@@ -1,0 +1,18 @@
+species: Tentacool
+setname: Prima
+item: [null]
+ability: [Clear Body,Liquid Ooze]
+moves:
+    - [Poison Jab]
+    - [Hydro Pump]
+    - [BubbleBeam]
+    - [Water Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/073_Tentacruel.yaml
+++ b/Prima/073_Tentacruel.yaml
@@ -1,0 +1,18 @@
+species: Tentacruel
+setname: Prima
+item: [null]
+ability: [Clear Body,Liquid Ooze]
+moves:
+    - [Wring Out]
+    - [Poison Jab]
+    - [Hydro Pump]
+    - [Water Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/074_Geodude.yaml
+++ b/Prima/074_Geodude.yaml
@@ -1,0 +1,18 @@
+species: Geodude
+setname: Prima
+item: [null]
+ability: [Rock Head,Sturdy]
+moves:
+    - [Hammer Arm]
+    - [Selfdestruct]
+    - [Double-edge]
+    - [Stone Edge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/075_Graveler.yaml
+++ b/Prima/075_Graveler.yaml
@@ -1,0 +1,18 @@
+species: Graveler
+setname: Prima
+item: [null]
+ability: [Rock Head,Sturdy]
+moves:
+    - [Earthquake]
+    - [Double-Edge]
+    - [Stone Edge]
+    - [Rock Blast]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/076_Golem.yaml
+++ b/Prima/076_Golem.yaml
@@ -1,0 +1,18 @@
+species: Golem
+setname: Prima
+item: [null]
+ability: [Rock Head,Sturdy]
+moves:
+    - [Double-Edge]
+    - [Earthquake]
+    - [Stone Edge]
+    - [Explosion]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/077_Ponyta.yaml
+++ b/Prima/077_Ponyta.yaml
@@ -1,0 +1,18 @@
+species: Ponyta
+setname: Prima
+item: [null]
+ability: [Run away,Flash Fire]
+moves:
+    - [Fire Blast]
+    - [Take Down]
+    - [Bounce]
+    - [Stomp]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/078_Rapidash.yaml
+++ b/Prima/078_Rapidash.yaml
@@ -1,0 +1,18 @@
+species: Rapidash
+setname: Prima
+item: [null]
+ability: [Run away,Flash Fire]
+moves:
+    - [Flamethrower]
+    - [Fire Blast]
+    - [Bounce]
+    - [Flare Blitz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/081_Magnemite.yaml
+++ b/Prima/081_Magnemite.yaml
@@ -1,0 +1,18 @@
+species: Magnemite
+setname: Prima
+item: [null]
+ability: [Magnet Pull,Sturdy]
+moves:
+    - [Gyro Ball]
+    - [Sonic Boom]
+    - [Super Sonic]
+    - [Zap Cannon]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/082_Magneton.yaml
+++ b/Prima/082_Magneton.yaml
@@ -1,0 +1,18 @@
+species: Magneton
+setname: Prima
+item: [null]
+ability: [Magnet Pull,Sturdy]
+moves:
+    - [Metal Sound]
+    - [SonicBoom]
+    - [Zap Cannon]
+    - [Flash Cannon]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/083_Farfetch'd.yaml
+++ b/Prima/083_Farfetch'd.yaml
@@ -1,0 +1,18 @@
+species: Farfetch'd
+setname: Prima
+item: [null]
+ability: [Keen Eye,Inner Focus]
+moves:
+    - [Air Slash]
+    - [Facade]
+    - [Sand Attack]
+    - [Steel Wing]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/084_Doduo.yaml
+++ b/Prima/084_Doduo.yaml
@@ -1,0 +1,18 @@
+species: Doduo
+setname: Prima
+item: [null]
+ability: [Run Away,Early Bird]
+moves:
+    - [Endeavor]
+    - [Quick Attack]
+    - [Drill Peck]
+    - [Brave Bird]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/085_Dodrio.yaml
+++ b/Prima/085_Dodrio.yaml
@@ -1,0 +1,18 @@
+species: Dodrio
+setname: Prima
+item: [null]
+ability: [Run Away,Early Bird]
+moves:
+    - [Endeavor]
+    - [Fly]
+    - [Drill Peck]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/086_Seel.yaml
+++ b/Prima/086_Seel.yaml
@@ -1,0 +1,18 @@
+species: Seel
+setname: Prima
+item: [null]
+ability: [Thick Fat,Hydration]
+moves:
+    - [Aqua Tail]
+    - [Brine]
+    - [Lick]
+    - [Dive]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/087_Dewgong.yaml
+++ b/Prima/087_Dewgong.yaml
@@ -1,0 +1,18 @@
+species: Dewgong
+setname: Prima
+item: [null]
+ability: [Thick Fat,Hydration]
+moves:
+    - [Aqua Tail]
+    - [Brine]
+    - [Sheer Cold]
+    - [Ice Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/088_Grimer.yaml
+++ b/Prima/088_Grimer.yaml
@@ -1,0 +1,18 @@
+species: Grimer
+setname: Prima
+item: [null]
+ability: [Stench,Sticky Hold]
+moves:
+    - [Memento]
+    - [Explosion]
+    - [Gunk Shot]
+    - [Sludge Bomb]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/089_Muk.yaml
+++ b/Prima/089_Muk.yaml
@@ -1,0 +1,18 @@
+species: Muk
+setname: Prima
+item: [null]
+ability: [Stench,Sticky Hold]
+moves:
+    - [Memento]
+    - [Gunk Shot]
+    - [Poison Jab]
+    - [Explosion]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/090_Shellder.yaml
+++ b/Prima/090_Shellder.yaml
@@ -1,0 +1,18 @@
+species: Shellder
+setname: Prima
+item: [null]
+ability: [Shell Armor,Skill Link]
+moves:
+    - [Brine]
+    - [Withdraw]
+    - [Protect]
+    - [Ice Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/091_Cloyster.yaml
+++ b/Prima/091_Cloyster.yaml
@@ -1,0 +1,18 @@
+species: Cloyster
+setname: Prima
+item: [null]
+ability: [Shell Armor,Skill Link]
+moves:
+    - [Withdraw]
+    - [Protect]
+    - [Surf]
+    - [Aurora Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/092_Gastly.yaml
+++ b/Prima/092_Gastly.yaml
@@ -1,0 +1,18 @@
+species: Gastly
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Nightmare]
+    - [Hypnosis]
+    - [Lick]
+    - [Perish Song]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/093_Haunter.yaml
+++ b/Prima/093_Haunter.yaml
@@ -1,0 +1,18 @@
+species: Haunter
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Nightmare]
+    - [Hypnosis]
+    - [Lick]
+    - [Dream Eater]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/094_Gengar.yaml
+++ b/Prima/094_Gengar.yaml
@@ -1,0 +1,18 @@
+species: Gengar
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Hypnosis]
+    - [Nightmare]
+    - [Lick]
+    - [Destiny Bond]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/095_Onix.yaml
+++ b/Prima/095_Onix.yaml
@@ -1,0 +1,18 @@
+species: Onix
+setname: Prima
+item: [null]
+ability: [Rock Head,Sturdy]
+moves:
+    - [Iron Tail]
+    - [Double-Edge]
+    - [Stone Edge]
+    - [Sand Tomb]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/096_Drowzee.yaml
+++ b/Prima/096_Drowzee.yaml
@@ -1,0 +1,18 @@
+species: Drowzee
+setname: Prima
+item: [null]
+ability: [Insomina,Forewarn]
+moves:
+    - [Disable]
+    - [Psychic]
+    - [Hypnosis]
+    - [Dream Eater]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/097_Hypno.yaml
+++ b/Prima/097_Hypno.yaml
@@ -1,0 +1,18 @@
+species: Hypno
+setname: Prima
+item: [null]
+ability: [Insomina,Forewarn]
+moves:
+    - [Dream Eater]
+    - [Future Sight]
+    - [Hypnosis]
+    - [Psychic]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/098_Krabby.yaml
+++ b/Prima/098_Krabby.yaml
@@ -1,0 +1,18 @@
+species: Krabby
+setname: Prima
+item: [null]
+ability: [Hyper Cutter,Shell Armor]
+moves:
+    - [Flail]
+    - [Guillotine]
+    - [BubbleBeam]
+    - [Metal Claw]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/099_Kingler.yaml
+++ b/Prima/099_Kingler.yaml
@@ -1,0 +1,18 @@
+species: Kingler
+setname: Prima
+item: [null]
+ability: [Hyper Cutter,Shell Armor]
+moves:
+    - [Crab Hammer]
+    - [Brine]
+    - [Flail]
+    - [Guillotine]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/100_Voltorb.yaml
+++ b/Prima/100_Voltorb.yaml
@@ -1,0 +1,18 @@
+species: Voltorb
+setname: Prima
+item: [null]
+ability: [Soundproof,Static]
+moves:
+    - [Explosion]
+    - [Thunder]
+    - [SonicBoom x3]
+    - [Charge Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/101_Electrode.yaml
+++ b/Prima/101_Electrode.yaml
@@ -1,0 +1,18 @@
+species: Electrode
+setname: Prima
+item: [null]
+ability: [Soundproof,Static]
+moves:
+    - [Gyro Ball]
+    - [SonicBoom]
+    - [Explosion]
+    - [Mirror Coat]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/102_Exeggcute.yaml
+++ b/Prima/102_Exeggcute.yaml
@@ -1,0 +1,18 @@
+species: Exeggcute
+setname: Prima
+item: [null]
+ability: [Chlorophyll]
+moves:
+    - [Synthesis]
+    - [Psychic]
+    - [SolarBeam]
+    - [Leech Seed]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/103_Exeggutor.yaml
+++ b/Prima/103_Exeggutor.yaml
@@ -1,0 +1,18 @@
+species: Exeggutor
+setname: Prima
+item: [null]
+ability: [Chlophoryll]
+moves:
+    - [Wood Hammer]
+    - [Psychic]
+    - [Egg Bomb]
+    - [Leaf Storm]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/104_Cubone.yaml
+++ b/Prima/104_Cubone.yaml
@@ -1,0 +1,18 @@
+species: Cubone
+setname: Prima
+item: [null]
+ability: [Rock Head,Lightning Rod]
+moves:
+    - [Endeavor]
+    - [Double-Edge]
+    - [Bone Rush]
+    - [Skull Bash]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/105_Marowak.yaml
+++ b/Prima/105_Marowak.yaml
@@ -1,0 +1,18 @@
+species: Marowak
+setname: Prima
+item: [null]
+ability: [Rock Head,Lightning Rod]
+moves:
+    - [Thrash]
+    - [Earthquake]
+    - [Double-Edge]
+    - [Bone Rush]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/106_Hitmonlee.yaml
+++ b/Prima/106_Hitmonlee.yaml
@@ -1,0 +1,18 @@
+species: Hitmonlee
+setname: Prima
+item: [null]
+ability: [Limber,Reckless]
+moves:
+    - [High Jump Kick]
+    - [Blaze Kick]
+    - [Rolling Kick]
+    - [Mega Kick]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/107_Hitmonchan.yaml
+++ b/Prima/107_Hitmonchan.yaml
@@ -1,0 +1,18 @@
+species: Hitmonchan
+setname: Prima
+item: [null]
+ability: [Keen eye,Iron Fist]
+moves:
+    - [Close Combat]
+    - [Focus Punch]
+    - [Sky Uppercut]
+    - [Mega Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/108_Lickitung.yaml
+++ b/Prima/108_Lickitung.yaml
@@ -1,0 +1,18 @@
+species: Lickitung
+setname: Prima
+item: [null]
+ability: [Own Tempo,Oblivious]
+moves:
+    - [Disable]
+    - [Rollout]
+    - [Lick]
+    - [Power Whip]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/109_Koffing.yaml
+++ b/Prima/109_Koffing.yaml
@@ -1,0 +1,18 @@
+species: Koffing
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Explosion]
+    - [Toxic]
+    - [Sludge Bomb]
+    - [Destiny bond]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/110_Weezing.yaml
+++ b/Prima/110_Weezing.yaml
@@ -1,0 +1,18 @@
+species: Weezing
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Memento]
+    - [Thunder]
+    - [Explosion]
+    - [Sludge Bomb]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/111_Rhyhorn.yaml
+++ b/Prima/111_Rhyhorn.yaml
@@ -1,0 +1,18 @@
+species: Rhyhorn
+setname: Prima
+item: [null]
+ability: [Lightningrod,Rock Head]
+moves:
+    - [Earthquake]
+    - [Horn Attack]
+    - [Horn Drill]
+    - [Mega Horn]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/112_Rhydon.yaml
+++ b/Prima/112_Rhydon.yaml
@@ -1,0 +1,18 @@
+species: Rhydon
+setname: Prima
+item: [null]
+ability: [Lightningrod,Rock Head]
+moves:
+    - [Earthquake]
+    - [Stone Edge]
+    - [Horn Drill]
+    - [Mega Horn]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/113_Chansey.yaml
+++ b/Prima/113_Chansey.yaml
@@ -1,0 +1,18 @@
+species: Chansey
+setname: Prima
+item: [null]
+ability: [Natrual Cure,Serene Grace]
+moves:
+    - [Double-Edge]
+    - [Softboiled]
+    - [Egg Bomb]
+    - [Minimize]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/114_Tangela.yaml
+++ b/Prima/114_Tangela.yaml
@@ -1,0 +1,18 @@
+species: Tangela
+setname: Prima
+item: [null]
+ability: [Chlorophyll,Leaf Guard]
+moves:
+    - [Wring Out]
+    - [Sleep Powder]
+    - [Power Whip]
+    - [Mega Drain]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/115_Kangaskhan.yaml
+++ b/Prima/115_Kangaskhan.yaml
@@ -1,0 +1,18 @@
+species: Kangaskhan
+setname: Prima
+item: [null]
+ability: [Early bird,Scrappy]
+moves:
+    - [Dizzy Punch]
+    - [Reversal]
+    - [Outrage]
+    - [Sucker Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/116_Horsea.yaml
+++ b/Prima/116_Horsea.yaml
@@ -1,0 +1,18 @@
+species: Horsea
+setname: Prima
+item: [null]
+ability: [Swift Swim,Sniper]
+moves:
+    - [Brine]
+    - [BubbleBeam]
+    - [Twister]
+    - [Dragon Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/117_Seadra.yaml
+++ b/Prima/117_Seadra.yaml
@@ -1,0 +1,18 @@
+species: Seadra
+setname: Prima
+item: [null]
+ability: [Poison Point,Sniper]
+moves:
+    - [Brine]
+    - [Hydro Pump]
+    - [BubbleBeam]
+    - [Dragon Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/118_Goldeen.yaml
+++ b/Prima/118_Goldeen.yaml
@@ -1,0 +1,18 @@
+species: Goldeen
+setname: Prima
+item: [null]
+ability: [Swift Swim,Water Veil]
+moves:
+    - [Fury attack]
+    - [Water Pulse]
+    - [Flail]
+    - [Megahorn]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/119_Seaking.yaml
+++ b/Prima/119_Seaking.yaml
@@ -1,0 +1,18 @@
+species: Seaking
+setname: Prima
+item: [null]
+ability: [Swift Swim,Water Veil]
+moves:
+    - [Aqua Ring]
+    - [Waterfall]
+    - [Surf]
+    - [Megahorn]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/120_Staryu.yaml
+++ b/Prima/120_Staryu.yaml
@@ -1,0 +1,18 @@
+species: Staryu
+setname: Prima
+item: [null]
+ability: [Illuminate,Natural Cure]
+moves:
+    - [Flash Cannon]
+    - [Hydro Pump]
+    - [Bubblebeam]
+    - [Recover]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/121_Starmie.yaml
+++ b/Prima/121_Starmie.yaml
@@ -1,0 +1,18 @@
+species: Starmie
+setname: Prima
+item: [null]
+ability: [Illuminate,Natural Cure]
+moves:
+    - [Trick Room]
+    - [Blizzard]
+    - [Hyper beam]
+    - [Water Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/122_Mr. Mime.yaml
+++ b/Prima/122_Mr. Mime.yaml
@@ -1,0 +1,18 @@
+species: Mr. Mime
+setname: Prima
+item: [null]
+ability: [Soundproof,Filter]
+moves:
+    - [Psychic]
+    - [Hypnosis]
+    - [Safeguard]
+    - [Mimic]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/123_Scyther.yaml
+++ b/Prima/123_Scyther.yaml
@@ -1,0 +1,18 @@
+species: Scyther
+setname: Prima
+item: [null]
+ability: [Swarm,Technician]
+moves:
+    - [Air Slash]
+    - [X-Scissor]
+    - [Swords Dance]
+    - [Bug Buzz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/124_Jynx.yaml
+++ b/Prima/124_Jynx.yaml
@@ -1,0 +1,18 @@
+species: Jynx
+setname: Prima
+item: [null]
+ability: [Oblivious,Forewarn]
+moves:
+    - [Lovely Kiss]
+    - [Shadow Ball]
+    - [Blizzard]
+    - [Perish Song]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/125_Electabuzz.yaml
+++ b/Prima/125_Electabuzz.yaml
@@ -1,0 +1,18 @@
+species: Electabuzz
+setname: Prima
+item: [null]
+ability: [Static]
+moves:
+    - [Rain Dance]
+    - [Thunder]
+    - [Thunder Punch]
+    - [Quick Attack]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/126_Magmar.yaml
+++ b/Prima/126_Magmar.yaml
@@ -1,0 +1,18 @@
+species: Magmar
+setname: Prima
+item: [null]
+ability: [Flame Body]
+moves:
+    - [Flamethrower]
+    - [Fire Blast]
+    - [Sunny Day]
+    - [Lava Plume]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/127_Pinsir.yaml
+++ b/Prima/127_Pinsir.yaml
@@ -1,0 +1,18 @@
+species: Pinsir
+setname: Prima
+item: [null]
+ability: [Hyper Cutter,Mold Breaker]
+moves:
+    - [Giga Impact]
+    - [X-Scissor]
+    - [Bind]
+    - [Guillotine]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/128_Tauros.yaml
+++ b/Prima/128_Tauros.yaml
@@ -1,0 +1,18 @@
+species: Tauros
+setname: Prima
+item: [null]
+ability: [Intimidate,Anger Point]
+moves:
+    - [Zen Headbutt]
+    - [Giga Impact]
+    - [Stone Edge]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/129_Magikarp.yaml
+++ b/Prima/129_Magikarp.yaml
@@ -1,0 +1,17 @@
+species: Magikarp
+setname: Prima
+item: [null]
+ability: [Swift Swim]
+moves:
+    - [Splash]
+    - [Tackle]
+    - [Flail]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/130_Gyarados.yaml
+++ b/Prima/130_Gyarados.yaml
@@ -1,0 +1,18 @@
+species: Gyarados
+setname: Prima
+item: [null]
+ability: [Intimidate]
+moves:
+    - [Thrash]
+    - [Hydro Pump]
+    - [Hyper Beam]
+    - [Dragon Dance]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/131_Lapras.yaml
+++ b/Prima/131_Lapras.yaml
@@ -1,0 +1,18 @@
+species: Lapras
+setname: Prima
+item: [null]
+ability: [Water Absorb,Shell Armor]
+moves:
+    - [Sing]
+    - [Sheer Cold]
+    - [Hydro Pump]
+    - [Attract]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/132_Ditto.yaml
+++ b/Prima/132_Ditto.yaml
@@ -1,0 +1,15 @@
+species: Ditto
+setname: Prima
+item: [null]
+ability: [Limber]
+moves:
+    - [Transform]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/133_Eevee.yaml
+++ b/Prima/133_Eevee.yaml
@@ -1,0 +1,18 @@
+species: Eevee
+setname: Prima
+item: [null]
+ability: [Run away,Adaptability]
+moves:
+    - [Bite]
+    - [Sand Attack]
+    - [Quick Attack]
+    - [Last Resort]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/134_Vaporeon.yaml
+++ b/Prima/134_Vaporeon.yaml
@@ -1,0 +1,18 @@
+species: Vaporeon
+setname: Prima
+item: [null]
+ability: [Water Absorb]
+moves:
+    - [Sand Attack]
+    - [Hydro Pump]
+    - [Last Resort]
+    - [Aurora Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/135_Jolteon.yaml
+++ b/Prima/135_Jolteon.yaml
@@ -1,0 +1,18 @@
+species: Jolteon
+setname: Prima
+item: [null]
+ability: [Static]
+moves:
+    - [Thunder]
+    - [Sand-Attack]
+    - [Last Resort]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/136_Flareon.yaml
+++ b/Prima/136_Flareon.yaml
@@ -1,0 +1,18 @@
+species: Flareon
+setname: Prima
+item: [null]
+ability: [Flash Fire]
+moves:
+    - [Sand Attack]
+    - [Smog]
+    - [Fire Blast]
+    - [Last Resort]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/137_Porygon.yaml
+++ b/Prima/137_Porygon.yaml
@@ -1,0 +1,18 @@
+species: Porygon
+setname: Prima
+item: [null]
+ability: [Trace,Download]
+moves:
+    - [Psybeam]
+    - [Signal Beam]
+    - [Zap Cannon]
+    - [Lock-On]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/138_Omanyte.yaml
+++ b/Prima/138_Omanyte.yaml
@@ -1,0 +1,18 @@
+species: Omanyte
+setname: Prima
+item: [null]
+ability: [Swift Swim,Shell Armor]
+moves:
+    - [Rain Dance]
+    - [AncientPower]
+    - [Hydro Pump]
+    - [Rock Blast]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/139_Omastar.yaml
+++ b/Prima/139_Omastar.yaml
@@ -1,0 +1,18 @@
+species: Omastar
+setname: Prima
+item: [null]
+ability: [Swift Swim,Shell Armor]
+moves:
+    - [AncientPower]
+    - [Brine]
+    - [Hydro Pump]
+    - [Rock Blast]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/140_Kabuto.yaml
+++ b/Prima/140_Kabuto.yaml
@@ -1,0 +1,18 @@
+species: Kabuto
+setname: Prima
+item: [null]
+ability: [Swift Swim,Battle Armor]
+moves:
+    - [Dig]
+    - [AncientPower]
+    - [Wring Out]
+    - [Surf]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/141_Kabutops.yaml
+++ b/Prima/141_Kabutops.yaml
@@ -1,0 +1,18 @@
+species: Kabutops
+setname: Prima
+item: [null]
+ability: [Swift Swim,Battle Armor]
+moves:
+    - [AncientPower]
+    - [Wring Out]
+    - [Stone Edge]
+    - [Night Slash]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/142_Aerodactyl.yaml
+++ b/Prima/142_Aerodactyl.yaml
@@ -1,0 +1,18 @@
+species: Aerodactyl
+setname: Prima
+item: [null]
+ability: [Rock Head,Pressure]
+moves:
+    - [Rock Slide]
+    - [Giga Impact]
+    - [Fly]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/143_Snorlax.yaml
+++ b/Prima/143_Snorlax.yaml
@@ -1,0 +1,18 @@
+species: Snorlax
+setname: Prima
+item: [null]
+ability: [Immunity,Thick Fat]
+moves:
+    - [Crunch]
+    - [Giga Impact]
+    - [Rest]
+    - [Body Slam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/144_Articuno.yaml
+++ b/Prima/144_Articuno.yaml
@@ -1,0 +1,18 @@
+species: Articuno
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Powder Snow]
+    - [Sheer Cold]
+    - [Blizzard]
+    - [Ice Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/145_Zapdos.yaml
+++ b/Prima/145_Zapdos.yaml
@@ -1,0 +1,18 @@
+species: Zapdos
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Thunder]
+    - [Drill Peck]
+    - [Roost]
+    - [Discharge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/146_Moltres.yaml
+++ b/Prima/146_Moltres.yaml
@@ -1,0 +1,18 @@
+species: Moltres
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Air Slash]
+    - [Sky Attack]
+    - [Fire Blast]
+    - [Heat Wave]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/147_Dratini.yaml
+++ b/Prima/147_Dratini.yaml
@@ -1,0 +1,18 @@
+species: Dratini
+setname: Prima
+item: [null]
+ability: [Shed Skin]
+moves:
+    - [Outrage]
+    - [Safeguard]
+    - [Hyper Beam]
+    - [Draco Meteor]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/148_Dragonair.yaml
+++ b/Prima/148_Dragonair.yaml
@@ -1,0 +1,18 @@
+species: Dragonair
+setname: Prima
+item: [null]
+ability: [Shed Skin]
+moves:
+    - [Outrage]
+    - [Dragon Rush]
+    - [Hyper Beam]
+    - [Draco Meteor]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/149_Dragonite.yaml
+++ b/Prima/149_Dragonite.yaml
@@ -1,0 +1,18 @@
+species: Dragonite
+setname: Prima
+item: [null]
+ability: [Inner Focus]
+moves:
+    - [Outrage]
+    - [Twister]
+    - [Hyper Beam]
+    - [Draco Meteor]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/150_Mewtwo.yaml
+++ b/Prima/150_Mewtwo.yaml
@@ -1,0 +1,18 @@
+species: Mewtwo
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Psychic]
+    - [Recover]
+    - [Aura Sphere]
+    - [Future Sight]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/151_Mew.yaml
+++ b/Prima/151_Mew.yaml
@@ -1,0 +1,18 @@
+species: Mew
+setname: Prima
+item: [null]
+ability: [Synchronize]
+moves:
+    - [Hyper Beam]
+    - [AncientPower]
+    - [Psychic]
+    - [Aura Sphere]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/152_Chikorita.yaml
+++ b/Prima/152_Chikorita.yaml
@@ -1,0 +1,18 @@
+species: Chikorita
+setname: Prima
+item: [null]
+ability: [Overgrow]
+moves:
+    - [Aromatherapy]
+    - [Giga Drain]
+    - [SolarBeam]
+    - [LeafStorm]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/153_Bayleef.yaml
+++ b/Prima/153_Bayleef.yaml
@@ -1,0 +1,18 @@
+species: Bayleef
+setname: Prima
+item: [null]
+ability: [Overgrow]
+moves:
+    - [Aromatherapy]
+    - [SolarBeam]
+    - [PoisonPowder]
+    - [Iron Tail]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/154_Meganium.yaml
+++ b/Prima/154_Meganium.yaml
@@ -1,0 +1,18 @@
+species: Meganium
+setname: Prima
+item: [null]
+ability: [Overgrow]
+moves:
+    - [Aromatherapy]
+    - [SolarBeam]
+    - [Frenzy Plant]
+    - [Petal Dance]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/155_Cyndaquil.yaml
+++ b/Prima/155_Cyndaquil.yaml
@@ -1,0 +1,18 @@
+species: Cyndaquil
+setname: Prima
+item: [null]
+ability: [Blaze]
+moves:
+    - [Flamethrower]
+    - [Fire Blast]
+    - [Quick Attack]
+    - [Lava Plume]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/156_Quilava.yaml
+++ b/Prima/156_Quilava.yaml
@@ -1,0 +1,18 @@
+species: Quilava
+setname: Prima
+item: [null]
+ability: [Blaze]
+moves:
+    - [Double-Edge]
+    - [Fire Blast]
+    - [Lava Plume]
+    - [Eruption]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/157_Typhlosion.yaml
+++ b/Prima/157_Typhlosion.yaml
@@ -1,0 +1,18 @@
+species: Typhlosion
+setname: Prima
+item: [null]
+ability: [Blaze]
+moves:
+    - [Flamethrower]
+    - [Rollout]
+    - [Double-Edge]
+    - [Eruption]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/158_Totodile.yaml
+++ b/Prima/158_Totodile.yaml
@@ -1,0 +1,18 @@
+species: Totodile
+setname: Prima
+item: [null]
+ability: [Torrent]
+moves:
+    - [Aqua Tail]
+    - [Bite]
+    - [Ice Fang]
+    - [Water Gun]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/159_Croconaw.yaml
+++ b/Prima/159_Croconaw.yaml
@@ -1,0 +1,18 @@
+species: Croconaw
+setname: Prima
+item: [null]
+ability: [Torrent]
+moves:
+    - [Aqua Tail]
+    - [Thrash]
+    - [Ice Fang]
+    - [Hydro Pump]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/160_Feraligatr.yaml
+++ b/Prima/160_Feraligatr.yaml
@@ -1,0 +1,18 @@
+species: Feraligatr
+setname: Prima
+item: [null]
+ability: [Torrent]
+moves:
+    - [Aqua Tail]
+    - [Crunch]
+    - [Hydro Pump]
+    - [Super Power]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/161_Sentret.yaml
+++ b/Prima/161_Sentret.yaml
@@ -1,0 +1,18 @@
+species: Sentret
+setname: Prima
+item: [null]
+ability: [Run Away,Keen Eye]
+moves:
+    - [Me First]
+    - [Quick Attack]
+    - [Hyper Voice]
+    - [Sucker Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/162_Furret.yaml
+++ b/Prima/162_Furret.yaml
@@ -1,0 +1,18 @@
+species: Furret
+setname: Prima
+item: [null]
+ability: [Run Away,Keen Eye]
+moves:
+    - [Rest]
+    - [Slam]
+    - [Hyper Voice]
+    - [Sucker Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/163_Hoothoot.yaml
+++ b/Prima/163_Hoothoot.yaml
@@ -1,0 +1,18 @@
+species: Hoothoot
+setname: Prima
+item: [null]
+ability: [Insomnia,Keen Eye]
+moves:
+    - [Sky Attack]
+    - [Extrasensory]
+    - [Fly]
+    - [Secret Power]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/164_Noctowl.yaml
+++ b/Prima/164_Noctowl.yaml
@@ -1,0 +1,18 @@
+species: Noctowl
+setname: Prima
+item: [null]
+ability: [Insomnia,Keen Eye]
+moves:
+    - [Air Slash]
+    - [Sky Attack]
+    - [Extrasensory]
+    - [Take Down]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/165_Ledyba.yaml
+++ b/Prima/165_Ledyba.yaml
@@ -1,0 +1,18 @@
+species: Ledyba
+setname: Prima
+item: [null]
+ability: [Swarm,Early Bird]
+moves:
+    - [Silver Wind]
+    - [Agility]
+    - [Roost]
+    - [Bug Buzz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/166_Ledian.yaml
+++ b/Prima/166_Ledian.yaml
@@ -1,0 +1,18 @@
+species: Ledian
+setname: Prima
+item: [null]
+ability: [Swarm,Early Bird]
+moves:
+    - [Silver Wind]
+    - [Double-Edge]
+    - [Aerial Ace]
+    - [Bug Buzz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/167_Spinarak.yaml
+++ b/Prima/167_Spinarak.yaml
@@ -1,0 +1,18 @@
+species: Spinarak
+setname: Prima
+item: [null]
+ability: [Swarm,Insomnia]
+moves:
+    - [Agility]
+    - [Psychic]
+    - [SonicBoom]
+    - [Poison Jab]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/168_Ariados.yaml
+++ b/Prima/168_Ariados.yaml
@@ -1,0 +1,18 @@
+species: Ariados
+setname: Prima
+item: [null]
+ability: [Swarm,Insomnia]
+moves:
+    - [Agility]
+    - [Solar Beam]
+    - [Psychic]
+    - [Poison Jab]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/169_Crobat.yaml
+++ b/Prima/169_Crobat.yaml
@@ -1,0 +1,18 @@
+species: Crobat
+setname: Prima
+item: [null]
+ability: [Inner Focus]
+moves:
+    - [Air Slash]
+    - [Fly]
+    - [Poison Fang]
+    - [Cross Poison]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/170_Chinchou.yaml
+++ b/Prima/170_Chinchou.yaml
@@ -1,0 +1,18 @@
+species: Chinchou
+setname: Prima
+item: [null]
+ability: [Volt Absorb,illuminate]
+moves:
+    - [Charge]
+    - [Hydro Pump]
+    - [BubbleBeam]
+    - [Discharge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/171_Lanturn.yaml
+++ b/Prima/171_Lanturn.yaml
@@ -1,0 +1,18 @@
+species: Lanturn
+setname: Prima
+item: [null]
+ability: [Volt Absorb,illuminate]
+moves:
+    - [Hydro Pump]
+    - [Charge]
+    - [Thunder]
+    - [Aqua Ring]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/172_Pichu.yaml
+++ b/Prima/172_Pichu.yaml
@@ -1,0 +1,18 @@
+species: Pichu
+setname: Prima
+item: [null]
+ability: [Static]
+moves:
+    - [Charm]
+    - [Thunder]
+    - [Reversal]
+    - [Nasty Plot]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/173_Cleffa.yaml
+++ b/Prima/173_Cleffa.yaml
@@ -1,0 +1,18 @@
+species: Cleffa
+setname: Prima
+item: [null]
+ability: [Cute Charm,Magic guard]
+moves:
+    - [Pound]
+    - [Magical Leaf]
+    - [Substitute]
+    - [Metronome]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/174_Igglybuff.yaml
+++ b/Prima/174_Igglybuff.yaml
@@ -1,0 +1,18 @@
+species: Igglybuff
+setname: Prima
+item: [null]
+ability: [Cute Charm]
+moves:
+    - [Sing]
+    - [Feint Attack]
+    - [Shock Wave]
+    - [Copycat]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/175_Togepi.yaml
+++ b/Prima/175_Togepi.yaml
@@ -1,0 +1,18 @@
+species: Togepi
+setname: Prima
+item: [null]
+ability: [Hustle,Serene Grace]
+moves:
+    - [Charm]
+    - [Follow Me]
+    - [Double-Edge]
+    - [Metronome]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/176_Togetic.yaml
+++ b/Prima/176_Togetic.yaml
@@ -1,0 +1,18 @@
+species: Togetic
+setname: Prima
+item: [null]
+ability: [Hustle,Serene Grace]
+moves:
+    - [Follow Me]
+    - [Solar beam]
+    - [Last Resort]
+    - [Metronome]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/177_Natu.yaml
+++ b/Prima/177_Natu.yaml
@@ -1,0 +1,18 @@
+species: Natu
+setname: Prima
+item: [null]
+ability: [Synchronize,Early Bird]
+moves:
+    - [Psychic]
+    - [Zen headbutt]
+    - [Drill Peck]
+    - [Future Sight]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/178_Xatu.yaml
+++ b/Prima/178_Xatu.yaml
@@ -1,0 +1,18 @@
+species: Xatu
+setname: Prima
+item: [null]
+ability: [Synchronize,Early bird]
+moves:
+    - [Psychic]
+    - [Fly]
+    - [Hyper Beam]
+    - [Wish]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/179_Mareep.yaml
+++ b/Prima/179_Mareep.yaml
@@ -1,0 +1,18 @@
+species: Mareep
+setname: Prima
+item: [null]
+ability: [Static]
+moves:
+    - [Rain Dance]
+    - [Thunder]
+    - [Power Gem]
+    - [Light Screen]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/180_Flaaffy.yaml
+++ b/Prima/180_Flaaffy.yaml
@@ -1,0 +1,18 @@
+species: Flaaffy
+setname: Prima
+item: [null]
+ability: [Static]
+moves:
+    - [Thunder]
+    - [Charge]
+    - [Power Gem]
+    - [Discharge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/181_Ampharos.yaml
+++ b/Prima/181_Ampharos.yaml
@@ -1,0 +1,18 @@
+species: Ampharos
+setname: Prima
+item: [null]
+ability: [Static]
+moves:
+    - [Thunder]
+    - [Giga Impact]
+    - [Power Gem]
+    - [Discharge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/182_Bellossom.yaml
+++ b/Prima/182_Bellossom.yaml
@@ -1,0 +1,18 @@
+species: Bellossom
+setname: Prima
+item: [null]
+ability: [Chlorophyll]
+moves:
+    - [Magical Leaf]
+    - [Sweet Scent]
+    - [Sunny Day]
+    - [Leaf Storm]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/183_Marill.yaml
+++ b/Prima/183_Marill.yaml
@@ -1,0 +1,18 @@
+species: Marill
+setname: Prima
+item: [null]
+ability: [Thick Fat,Huge Power]
+moves:
+    - [Aqua Tail]
+    - [Tail Whip]
+    - [Hydro Pump]
+    - [Bubble Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/184_Azumarill.yaml
+++ b/Prima/184_Azumarill.yaml
@@ -1,0 +1,18 @@
+species: Azumarill
+setname: Prima
+item: [null]
+ability: [Thick Fat,Huge Power]
+moves:
+    - [Aqua Tail]
+    - [Rain Dance]
+    - [Double-Edge]
+    - [Hydro Pump]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/185_Sudowoodo.yaml
+++ b/Prima/185_Sudowoodo.yaml
@@ -1,0 +1,18 @@
+species: Sudowoodo
+setname: Prima
+item: [null]
+ability: [Sturdy,Rock Head]
+moves:
+    - [Hammer Arm]
+    - [Rock Slide]
+    - [Double-Edge]
+    - [Mimic]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/186_Politoed.yaml
+++ b/Prima/186_Politoed.yaml
@@ -1,0 +1,18 @@
+species: Politoed
+setname: Prima
+item: [null]
+ability: [Water Absorb,Damp]
+moves:
+    - [Hypnosis]
+    - [Bounce]
+    - [BubbleBeam]
+    - [Perish Song]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/187_Hoppip.yaml
+++ b/Prima/187_Hoppip.yaml
@@ -1,0 +1,18 @@
+species: Hoppip
+setname: Prima
+item: [null]
+ability: [Chlorophyll,Leaf Guard]
+moves:
+    - [Memento]
+    - [Giga Drain]
+    - [Synthesis]
+    - [Poison Powder]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/188_Skiploom.yaml
+++ b/Prima/188_Skiploom.yaml
@@ -1,0 +1,18 @@
+species: Skiploom
+setname: Prima
+item: [null]
+ability: [Chlorophyll,Leaf Guard]
+moves:
+    - [Memento]
+    - [Giga Drain]
+    - [Bounce]
+    - [U-turn]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/189_Jumpluff.yaml
+++ b/Prima/189_Jumpluff.yaml
@@ -1,0 +1,18 @@
+species: Jumpluff
+setname: Prima
+item: [null]
+ability: [Chlorophyll,Leaf Guard]
+moves:
+    - [Memento]
+    - [Giga Drain]
+    - [SolarBeam]
+    - [Bounce]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/190_Aipom.yaml
+++ b/Prima/190_Aipom.yaml
@@ -1,0 +1,18 @@
+species: Aipom
+setname: Prima
+item: [null]
+ability: [Run Away,Pick up]
+moves:
+    - [Screech]
+    - [Astonish]
+    - [Agility]
+    - [Last Resort]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/191_Sunkern.yaml
+++ b/Prima/191_Sunkern.yaml
@@ -1,0 +1,18 @@
+species: Sunkern
+setname: Prima
+item: [null]
+ability: [Chlorophyll,Solar Power]
+moves:
+    - [Giga Drain]
+    - [Bullet Seed]
+    - [Sunny day]
+    - [Razor Leaf]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/192_Sunflora.yaml
+++ b/Prima/192_Sunflora.yaml
@@ -1,0 +1,18 @@
+species: Sunflora
+setname: Prima
+item: [null]
+ability: [Chlorophyll,Solar Power]
+moves:
+    - [Solar Beam]
+    - [Sunny Day]
+    - [Leech Seed]
+    - [Leaf Storm]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/193_Yanma.yaml
+++ b/Prima/193_Yanma.yaml
@@ -1,0 +1,18 @@
+species: Yanma
+setname: Prima
+item: [null]
+ability: [Speed Boost,Compoundeyes]
+moves:
+    - [Air Slash]
+    - [Silver Wind]
+    - [U-turn]
+    - [Bug Buzz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/194_Wooper.yaml
+++ b/Prima/194_Wooper.yaml
@@ -1,0 +1,18 @@
+species: Wooper
+setname: Prima
+item: [null]
+ability: [Damp,Water Absorb]
+moves:
+    - [Rain Dance]
+    - [Earthquake]
+    - [Muddy Water]
+    - [Mud Bomb]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/195_Quagsire.yaml
+++ b/Prima/195_Quagsire.yaml
@@ -1,0 +1,18 @@
+species: Quagsire
+setname: Prima
+item: [null]
+ability: [Damp,Water Absorb]
+moves:
+    - [Rain Dance]
+    - [Earthquake]
+    - [Muddy Water]
+    - [Slam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/196_Espeon.yaml
+++ b/Prima/196_Espeon.yaml
@@ -1,0 +1,18 @@
+species: Espeon
+setname: Prima
+item: [null]
+ability: [Synchronize]
+moves:
+    - [Morning Sun]
+    - [Psychic]
+    - [Sand Attack]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/197_Umbreon.yaml
+++ b/Prima/197_Umbreon.yaml
@@ -1,0 +1,18 @@
+species: Umbreon
+setname: Prima
+item: [null]
+ability: [Synchronize]
+moves:
+    - [Sand Attack]
+    - [Moonlight]
+    - [Assurance]
+    - [Last Resort]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/198_Murkrow.yaml
+++ b/Prima/198_Murkrow.yaml
@@ -1,0 +1,18 @@
+species: Murkrow
+setname: Prima
+item: [null]
+ability: [Insomnia,Super Luck]
+moves:
+    - [Dark Pulse]
+    - [Fly]
+    - [Drill Peck]
+    - [Sucker Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/199_Slowking.yaml
+++ b/Prima/199_Slowking.yaml
@@ -1,0 +1,18 @@
+species: Slowking
+setname: Prima
+item: [null]
+ability: [Oblivious,Own Tempo]
+moves:
+    - [Yawn]
+    - [Trump Card]
+    - [Psychic]
+    - [Surf]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/200_Misdreavus.yaml
+++ b/Prima/200_Misdreavus.yaml
@@ -1,0 +1,18 @@
+species: Misdreavus
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Ominous Wind]
+    - [Psybeam]
+    - [Shadow Ball]
+    - [Perish Song]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/201_Unown.yaml
+++ b/Prima/201_Unown.yaml
@@ -1,0 +1,15 @@
+species: Unown
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Hiddden Power]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/202_Wobbuffet.yaml
+++ b/Prima/202_Wobbuffet.yaml
@@ -1,0 +1,18 @@
+species: Wobbuffet
+setname: Prima
+item: [null]
+ability: [Shadow Tag]
+moves:
+    - [Counter]
+    - [Safeguard]
+    - [Destiny Bond]
+    - [Mirror Coat]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/203_Girafarig.yaml
+++ b/Prima/203_Girafarig.yaml
@@ -1,0 +1,18 @@
+species: Girafarig
+setname: Prima
+item: [null]
+ability: [Inner Focus,Early Bird]
+moves:
+    - [Crunch]
+    - [Psychic]
+    - [Zen Headbutt]
+    - [Mirror Coat]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/204_Pineco.yaml
+++ b/Prima/204_Pineco.yaml
@@ -1,0 +1,18 @@
+species: Pineco
+setname: Prima
+item: [null]
+ability: [Sturdy]
+moves:
+    - [Giga Drain]
+    - [Payback]
+    - [Explosion]
+    - [Pin Missile]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/205_Forretress.yaml
+++ b/Prima/205_Forretress.yaml
@@ -1,0 +1,18 @@
+species: Forretress
+setname: Prima
+item: [null]
+ability: [Sturdy]
+moves:
+    - [Gyro Ball]
+    - [Explosion]
+    - [Zap Cannon]
+    - [Flash Cannon]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/206_Dunsparce.yaml
+++ b/Prima/206_Dunsparce.yaml
@@ -1,0 +1,18 @@
+species: Dunsparce
+setname: Prima
+item: [null]
+ability: [Serene Grace,Run Away]
+moves:
+    - [Dig]
+    - [Pursuit]
+    - [Roost]
+    - [Glare]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/207_Gligar.yaml
+++ b/Prima/207_Gligar.yaml
@@ -1,0 +1,18 @@
+species: Gligar
+setname: Prima
+item: [null]
+ability: [Hyper Cutter,Sand Veil]
+moves:
+    - [Dig]
+    - [Earthquake]
+    - [Wing Attack]
+    - [Guillotine]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/208_Steelix.yaml
+++ b/Prima/208_Steelix.yaml
@@ -1,0 +1,18 @@
+species: Steelix
+setname: Prima
+item: [null]
+ability: [Sturdy,Rock Head]
+moves:
+    - [Earthquake]
+    - [Bind]
+    - [Double-edge]
+    - [Flash Cannon]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/209_Snubbull.yaml
+++ b/Prima/209_Snubbull.yaml
@@ -1,0 +1,18 @@
+species: Snubbull
+setname: Prima
+item: [null]
+ability: [Intimdate,Run Away]
+moves:
+    - [Charm]
+    - [Heal Bell]
+    - [Bite]
+    - [Substitute]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/210_Granbull.yaml
+++ b/Prima/210_Granbull.yaml
@@ -1,0 +1,18 @@
+species: Granbull
+setname: Prima
+item: [null]
+ability: [Intimidate,Quick Feet]
+moves:
+    - [Crunch]
+    - [Thunder Fang]
+    - [Ice Fang]
+    - [Fire Fang]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/211_Qwilfish.yaml
+++ b/Prima/211_Qwilfish.yaml
@@ -1,0 +1,18 @@
+species: Qwilfish
+setname: Prima
+item: [null]
+ability: [Poison Point,Swift Swim]
+moves:
+    - [Aqua Tail]
+    - [Poison Jab]
+    - [Hydro Pump]
+    - [Destiny Bond]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/212_Scizor.yaml
+++ b/Prima/212_Scizor.yaml
@@ -1,0 +1,18 @@
+species: Scizor
+setname: Prima
+item: [null]
+ability: [Swarm,Technician]
+moves:
+    - [Iron Head]
+    - [Giga impact]
+    - [X-Scissor]
+    - [Swords Dance]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/213_Shuckle.yaml
+++ b/Prima/213_Shuckle.yaml
@@ -1,0 +1,18 @@
+species: Shuckle
+setname: Prima
+item: [null]
+ability: [Sturdy,Gluttony]
+moves:
+    - [Super Power]
+    - [Withdraw]
+    - [Stone Edge]
+    - [Rest]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/214_Heracross.yaml
+++ b/Prima/214_Heracross.yaml
@@ -1,0 +1,18 @@
+species: Heracross
+setname: Prima
+item: [null]
+ability: [Swarm,Guts]
+moves:
+    - [Close combat]
+    - [Focus Punch]
+    - [Reversal]
+    - [Mega Horn]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/215_Sneasel.yaml
+++ b/Prima/215_Sneasel.yaml
@@ -1,0 +1,18 @@
+species: Sneasel
+setname: Prima
+item: [null]
+ability: [Inner Focus,Keen eye]
+moves:
+    - [Dark Pulse]
+    - [Ice Shard]
+    - [Blizzard]
+    - [Ice Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/216_Teddiursa.yaml
+++ b/Prima/216_Teddiursa.yaml
@@ -1,0 +1,18 @@
+species: Teddiursa
+setname: Prima
+item: [null]
+ability: [Pick Up,Quick Feet]
+moves:
+    - [Thrash]
+    - [Sweet Scent]
+    - [Slash]
+    - [Feint Attack]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/217_Ursaring.yaml
+++ b/Prima/217_Ursaring.yaml
@@ -1,0 +1,18 @@
+species: Ursaring
+setname: Prima
+item: [null]
+ability: [Guts,Quick Feet]
+moves:
+    - [Hammer Arm]
+    - [Thrash]
+    - [Sweet Scent]
+    - [Snore]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/218_Slugma.yaml
+++ b/Prima/218_Slugma.yaml
@@ -1,0 +1,18 @@
+species: Slugma
+setname: Prima
+item: [null]
+ability: [Magma Armor,Flame Body]
+moves:
+    - [Flamethrower]
+    - [Ancient Power]
+    - [Yawn]
+    - [Lava Plume]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/219_Magcargo.yaml
+++ b/Prima/219_Magcargo.yaml
@@ -1,0 +1,18 @@
+species: Magcargo
+setname: Prima
+item: [null]
+ability: [Magma Armor,Flame Body]
+moves:
+    - [Rock Slide]
+    - [Flamethrower]
+    - [Earth Power]
+    - [Body Slam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/220_Swinub.yaml
+++ b/Prima/220_Swinub.yaml
@@ -1,0 +1,18 @@
+species: Swinub
+setname: Prima
+item: [null]
+ability: [Oblivious,Snow Cloak]
+moves:
+    - [Odor Sleuth]
+    - [Earthquake]
+    - [Blizzard]
+    - [Take Down]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/221_Piloswine.yaml
+++ b/Prima/221_Piloswine.yaml
@@ -1,0 +1,18 @@
+species: Piloswine
+setname: Prima
+item: [null]
+ability: [Oblivious,Snow Cloak]
+moves:
+    - [Ice Fang]
+    - [Earthquake]
+    - [Blizzard]
+    - [Ice Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/222_Corsola.yaml
+++ b/Prima/222_Corsola.yaml
@@ -1,0 +1,18 @@
+species: Corsola
+setname: Prima
+item: [null]
+ability: [Hustle,Natural Cure]
+moves:
+    - [Aqua Ring]
+    - [Earth Power]
+    - [Bubble Beam]
+    - [Power Gem]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/223_Remoraid.yaml
+++ b/Prima/223_Remoraid.yaml
@@ -1,0 +1,18 @@
+species: Remoraid
+setname: Prima
+item: [null]
+ability: [Hustle,Sniper]
+moves:
+    - [Water Gun]
+    - [Bubble Beam]
+    - [Hyper Beam]
+    - [Psybeam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/224_Octillery.yaml
+++ b/Prima/224_Octillery.yaml
@@ -1,0 +1,18 @@
+species: Octillery
+setname: Prima
+item: [null]
+ability: [Hustle,Sniper]
+moves:
+    - [Octazooka]
+    - [Gunk Shot]
+    - [Hyper Beam]
+    - [Bubble Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/225_Delibird.yaml
+++ b/Prima/225_Delibird.yaml
@@ -1,0 +1,18 @@
+species: Delibird
+setname: Prima
+item: [null]
+ability: [Vital Spirit,Hustle]
+moves:
+    - [Focus Punch]
+    - [Fly]
+    - [Future Sight]
+    - [Ice Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/226_Mantine.yaml
+++ b/Prima/226_Mantine.yaml
@@ -1,0 +1,18 @@
+species: Mantine
+setname: Prima
+item: [null]
+ability: [Swift swim,Water Absorb]
+moves:
+    - [Psybeam]
+    - [Aerial Ace]
+    - [Hydro Pump]
+    - [Aqua Ring]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/227_Skarmory.yaml
+++ b/Prima/227_Skarmory.yaml
@@ -1,0 +1,18 @@
+species: Skarmory
+setname: Prima
+item: [null]
+ability: [Keen Eye,Sturdy]
+moves:
+    - [Air Slash]
+    - [Fly]
+    - [Steel Wing]
+    - [Brave Bird]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/228_Houndour.yaml
+++ b/Prima/228_Houndour.yaml
@@ -1,0 +1,18 @@
+species: Houndour
+setname: Prima
+item: [null]
+ability: [Early bird,Flash Fire]
+moves:
+    - [Flamethrower]
+    - [Crunch]
+    - [Fire Fang]
+    - [Nasty Plot]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/229_Houndoom.yaml
+++ b/Prima/229_Houndoom.yaml
@@ -1,0 +1,18 @@
+species: Houndoom
+setname: Prima
+item: [null]
+ability: [Early Bird,Flash Fire]
+moves:
+    - [Crunch]
+    - [Thunder Fang]
+    - [Fire Blast]
+    - [Fire Fang]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/230_Kingdra.yaml
+++ b/Prima/230_Kingdra.yaml
@@ -1,0 +1,18 @@
+species: Kingdra
+setname: Prima
+item: [null]
+ability: [Swift Swim,Sniper]
+moves:
+    - [Twister]
+    - [Hydro Pump]
+    - [Bubble Beam]
+    - [Dragon Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/231_Phanpy.yaml
+++ b/Prima/231_Phanpy.yaml
@@ -1,0 +1,18 @@
+species: Phanpy
+setname: Prima
+item: [null]
+ability: [Pick Up]
+moves:
+    - [Earthquake]
+    - [Double edge]
+    - [Take Down]
+    - [Body Slam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/232_Donphan.yaml
+++ b/Prima/232_Donphan.yaml
@@ -1,0 +1,18 @@
+species: Donphan
+setname: Prima
+item: [null]
+ability: [Sturdy]
+moves:
+    - [Thunder fang]
+    - [Giga Impact]
+    - [Earthquake]
+    - [Fire Fang]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/233_Porygon2.yaml
+++ b/Prima/233_Porygon2.yaml
@@ -1,0 +1,18 @@
+species: Porygon2
+setname: Prima
+item: [null]
+ability: [Trace,Download]
+moves:
+    - [Recover]
+    - [Conversion 2]
+    - [Hyper Beam]
+    - [Discharge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/234_Stantler.yaml
+++ b/Prima/234_Stantler.yaml
@@ -1,0 +1,18 @@
+species: Stantler
+setname: Prima
+item: [null]
+ability: [Intimidate,Frisk]
+moves:
+    - [Hypnosis]
+    - [Zen Headbutt]
+    - [Take Down]
+    - [Captivate]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/235_Smeargle.yaml
+++ b/Prima/235_Smeargle.yaml
@@ -1,0 +1,15 @@
+species: Smeargle
+setname: Prima
+item: [null]
+ability: [Own Tempo,Technician]
+moves:
+    - [Sketch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/236_Tyrogue.yaml
+++ b/Prima/236_Tyrogue.yaml
@@ -1,0 +1,18 @@
+species: Tyrogue
+setname: Prima
+item: [null]
+ability: [Guts,steadfast]
+moves:
+    - [Rock Slide]
+    - [Earthquake]
+    - [High Jump Kick]
+    - [Bullet Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/237_Hitmontop.yaml
+++ b/Prima/237_Hitmontop.yaml
@@ -1,0 +1,18 @@
+species: Hitmontop
+setname: Prima
+item: [null]
+ability: [Intimidate,Technican]
+moves:
+    - [Close Combat]
+    - [Endavor]
+    - [Brick break]
+    - [Focus Energy]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/238_Smoochum.yaml
+++ b/Prima/238_Smoochum.yaml
@@ -1,0 +1,18 @@
+species: Smoochum
+setname: Prima
+item: [null]
+ability: [Oblivious,Forewarn]
+moves:
+    - [Psychic]
+    - [Sweet Kiss]
+    - [Blizzard]
+    - [Perish Song]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/239_Elekid.yaml
+++ b/Prima/239_Elekid.yaml
@@ -1,0 +1,18 @@
+species: Elekid
+setname: Prima
+item: [null]
+ability: [Static]
+moves:
+    - [Rain Dance]
+    - [Thunder]
+    - [Thunderbolt]
+    - [Shock Wave]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/240_Magby.yaml
+++ b/Prima/240_Magby.yaml
@@ -1,0 +1,18 @@
+species: Magby
+setname: Prima
+item: [null]
+ability: [Flame Body]
+moves:
+    - [Flamethrower]
+    - [Fire Blast]
+    - [Sunny Day]
+    - [Fire Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/241_Miltank.yaml
+++ b/Prima/241_Miltank.yaml
@@ -1,0 +1,18 @@
+species: Miltank
+setname: Prima
+item: [null]
+ability: [Thick fat,Scrappy]
+moves:
+    - [Heal bell]
+    - [Zen Headbutt]
+    - [Milk Drink]
+    - [Wake-up Slap]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/242_Blissey.yaml
+++ b/Prima/242_Blissey.yaml
@@ -1,0 +1,18 @@
+species: Blissey
+setname: Prima
+item: [null]
+ability: [Natural Cure,Serene Grace]
+moves:
+    - [Charge Beam]
+    - [Sing]
+    - [Soft Boiled]
+    - [Egg Bomb]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/243_Raikou.yaml
+++ b/Prima/243_Raikou.yaml
@@ -1,0 +1,18 @@
+species: Raikou
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Thunder]
+    - [Extrasenssory]
+    - [Thunder wave]
+    - [Discharge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/244_Entei.yaml
+++ b/Prima/244_Entei.yaml
@@ -1,0 +1,18 @@
+species: Entei
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Flamethrower]
+    - [Extrasensory]
+    - [Fire blast]
+    - [Lave plume]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/245_Suicune.yaml
+++ b/Prima/245_Suicune.yaml
@@ -1,0 +1,18 @@
+species: Suicune
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Ice Fang]
+    - [Extrasensory]
+    - [Hydro Pump]
+    - [Bubble Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/246_Larvitar.yaml
+++ b/Prima/246_Larvitar.yaml
@@ -1,0 +1,18 @@
+species: Larvitar
+setname: Prima
+item: [null]
+ability: [Guts]
+moves:
+    - [Thrash]
+    - [Earthquake]
+    - [Stone Edge]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/247_Pupitar.yaml
+++ b/Prima/247_Pupitar.yaml
@@ -1,0 +1,18 @@
+species: Pupitar
+setname: Prima
+item: [null]
+ability: [Shed Skin]
+moves:
+    - [Dark Pulse]
+    - [Earthquake]
+    - [Stone Edge]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/248_Tyranitar.yaml
+++ b/Prima/248_Tyranitar.yaml
@@ -1,0 +1,18 @@
+species: Tyranitar
+setname: Prima
+item: [null]
+ability: [Sand Stream]
+moves:
+    - [Crunch]
+    - [Stone Edge]
+    - [Earthquake]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/249_Lugia.yaml
+++ b/Prima/249_Lugia.yaml
@@ -1,0 +1,18 @@
+species: Lugia
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Aero Blast]
+    - [Giga Impact]
+    - [Sky attack]
+    - [Psychic]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/250_Ho-Oh.yaml
+++ b/Prima/250_Ho-Oh.yaml
@@ -1,0 +1,18 @@
+species: Ho-Oh
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Sky Attack]
+    - [Psychic]
+    - [Sacred Fire]
+    - [Fire Blast]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/251_Celebi.yaml
+++ b/Prima/251_Celebi.yaml
@@ -1,0 +1,18 @@
+species: Celebi
+setname: Prima
+item: [null]
+ability: [Natural Cure]
+moves:
+    - [Healing Wish]
+    - [Psychic]
+    - [Perish Song]
+    - [Leaf Storm]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/252_Treecko.yaml
+++ b/Prima/252_Treecko.yaml
@@ -1,0 +1,18 @@
+species: Treecko
+setname: Prima
+item: [null]
+ability: [Overgrow]
+moves:
+    - [Energy Ball]
+    - [Giga Drain]
+    - [Grasswhistle]
+    - [Solar Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/253_Grovyle.yaml
+++ b/Prima/253_Grovyle.yaml
@@ -1,0 +1,18 @@
+species: Grovyle
+setname: Prima
+item: [null]
+ability: [Overgrow]
+moves:
+    - [Pursuit]
+    - [Slam]
+    - [Leaf Storm]
+    - [Leaf Blade]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/254_Sceptile.yaml
+++ b/Prima/254_Sceptile.yaml
@@ -1,0 +1,18 @@
+species: Sceptile
+setname: Prima
+item: [null]
+ability: [Overgrow]
+moves:
+    - [Giga Drain]
+    - [Slam]
+    - [Leaf Storm]
+    - [Leaf Blade]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/255_Torchic.yaml
+++ b/Prima/255_Torchic.yaml
@@ -1,0 +1,18 @@
+species: Torchic
+setname: Prima
+item: [null]
+ability: [Blaze]
+moves:
+    - [Flamethrower]
+    - [Slash]
+    - [Peck]
+    - [Fire Spin]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/256_Combusken.yaml
+++ b/Prima/256_Combusken.yaml
@@ -1,0 +1,18 @@
+species: Combusken
+setname: Prima
+item: [null]
+ability: [Blaze]
+moves:
+    - [Mirror Move]
+    - [Slash]
+    - [Sky Uppercut]
+    - [Flare Blitz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/257_Blaziken.yaml
+++ b/Prima/257_Blaziken.yaml
@@ -1,0 +1,18 @@
+species: Blaziken
+setname: Prima
+item: [null]
+ability: [Blaze]
+moves:
+    - [Sky Uppercut]
+    - [Flare Blitz]
+    - [Blaze Kick]
+    - [Brave Bird]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/258_Mudkip.yaml
+++ b/Prima/258_Mudkip.yaml
@@ -1,0 +1,18 @@
+species: Mudkip
+setname: Prima
+item: [null]
+ability: [Torrent]
+moves:
+    - [Whirlpool]
+    - [Mud Sport]
+    - [Hydro Pump]
+    - [Water Gun]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/259_Marshtomp.yaml
+++ b/Prima/259_Marshtomp.yaml
@@ -1,0 +1,18 @@
+species: Marshtomp
+setname: Prima
+item: [null]
+ability: [Torrent]
+moves:
+    - [Earthquake]
+    - [Muddy Water]
+    - [Mud Shot]
+    - [Ice Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/260_Swampert.yaml
+++ b/Prima/260_Swampert.yaml
@@ -1,0 +1,18 @@
+species: Swampert
+setname: Prima
+item: [null]
+ability: [Torrent]
+moves:
+    - [Hammer Arm]
+    - [Endeavor]
+    - [Earthquake]
+    - [Muddy Water]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/261_Poochyena.yaml
+++ b/Prima/261_Poochyena.yaml
@@ -1,0 +1,18 @@
+species: Poochyena
+setname: Prima
+item: [null]
+ability: [Run Away,Quick Feet]
+moves:
+    - [Crunch]
+    - [Sand Attack]
+    - [Poison Fang]
+    - [Sucker Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/262_Mightyena.yaml
+++ b/Prima/262_Mightyena.yaml
@@ -1,0 +1,18 @@
+species: Mightyena
+setname: Prima
+item: [null]
+ability: [Intimidate,Quick Feet]
+moves:
+    - [Giga Impact]
+    - [Sand Attack]
+    - [Take Down]
+    - [Sucker Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/263_Zigzagoon.yaml
+++ b/Prima/263_Zigzagoon.yaml
@@ -1,0 +1,18 @@
+species: Zigzagoon
+setname: Prima
+item: [null]
+ability: [Pick Up,Gluttony]
+moves:
+    - [Sand Attack]
+    - [Headbutt]
+    - [Covet]
+    - [Pin Missile]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/264_Linoone.yaml
+++ b/Prima/264_Linoone.yaml
@@ -1,0 +1,18 @@
+species: Linoone
+setname: Prima
+item: [null]
+ability: [Pick Up,Gluttony]
+moves:
+    - [Sand Attack]
+    - [Slash]
+    - [Tail Whip]
+    - [Belly Drum]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/265_Wurmple.yaml
+++ b/Prima/265_Wurmple.yaml
@@ -1,0 +1,17 @@
+species: Wurmple
+setname: Prima
+item: [null]
+ability: [Sheild Dust]
+moves:
+    - [String Shot]
+    - [Tackle]
+    - [Poison Sting]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/266_Silcoon.yaml
+++ b/Prima/266_Silcoon.yaml
@@ -1,0 +1,15 @@
+species: Silcoon
+setname: Prima
+item: [null]
+ability: [Shed Skin]
+moves:
+    - [Harden]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/267_Beautifly.yaml
+++ b/Prima/267_Beautifly.yaml
@@ -1,0 +1,18 @@
+species: Beautifly
+setname: Prima
+item: [null]
+ability: [Swarm]
+moves:
+    - [Giga Drain]
+    - [Silver Wind]
+    - [U-turn]
+    - [Bug Buzz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/268_Cascoon.yaml
+++ b/Prima/268_Cascoon.yaml
@@ -1,0 +1,15 @@
+species: Cascoon
+setname: Prima
+item: [null]
+ability: [Shed Skin]
+moves:
+    - [Harden]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/269_Dustox.yaml
+++ b/Prima/269_Dustox.yaml
@@ -1,0 +1,18 @@
+species: Dustox
+setname: Prima
+item: [null]
+ability: [Shield Dust]
+moves:
+    - [Silver Wind]
+    - [Toxic]
+    - [Sludge Bomb]
+    - [Bug Buzz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/270_Lotad.yaml
+++ b/Prima/270_Lotad.yaml
@@ -1,0 +1,18 @@
+species: Lotad
+setname: Prima
+item: [null]
+ability: [Swift Swim,Rain Dish]
+moves:
+    - [Rain dance]
+    - [Energy Ball]
+    - [Giga Drain]
+    - [Zen Headbutt]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/271_Lombre.yaml
+++ b/Prima/271_Lombre.yaml
@@ -1,0 +1,18 @@
+species: Lombre
+setname: Prima
+item: [null]
+ability: [Swift Swim,Rain Dish]
+moves:
+    - [Giga Drain]
+    - [Solar Beam]
+    - [Hydro Pump]
+    - [Water Sport]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/272_Ludicolo.yaml
+++ b/Prima/272_Ludicolo.yaml
@@ -1,0 +1,18 @@
+species: Ludicolo
+setname: Prima
+item: [null]
+ability: [Swift Swim,Rain Dish]
+moves:
+    - [Rain Dance]
+    - [Astonish]
+    - [Surf]
+    - [Solar Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/276_Taillow.yaml
+++ b/Prima/276_Taillow.yaml
@@ -1,0 +1,18 @@
+species: Taillow
+setname: Prima
+item: [null]
+ability: [Guts]
+moves:
+    - [Air Slash]
+    - [Endeavor]
+    - [Sky Attack]
+    - [Aerial Ace]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/277_Swellow.yaml
+++ b/Prima/277_Swellow.yaml
@@ -1,0 +1,18 @@
+species: Swellow
+setname: Prima
+item: [null]
+ability: [Guts]
+moves:
+    - [Air Slash]
+    - [Fly]
+    - [Aerial ace]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/278_Wingull.yaml
+++ b/Prima/278_Wingull.yaml
@@ -1,0 +1,18 @@
+species: Wingull
+setname: Prima
+item: [null]
+ability: [Keen Eye]
+moves:
+    - [Air Slash]
+    - [Brine]
+    - [Roost]
+    - [Water Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/279_Pelipper.yaml
+++ b/Prima/279_Pelipper.yaml
@@ -1,0 +1,18 @@
+species: Pelipper
+setname: Prima
+item: [null]
+ability: [Keen Eye]
+moves:
+    - [Fly]
+    - [Wing Attack]
+    - [Hydro Pump]
+    - [Blizzard]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/280_Ralts.yaml
+++ b/Prima/280_Ralts.yaml
@@ -1,0 +1,18 @@
+species: Ralts
+setname: Prima
+item: [null]
+ability: [Synchronize,Trace]
+moves:
+    - [Hypnosis]
+    - [Magical Leaf]
+    - [Destiny Bond]
+    - [Dream Eater]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/281_Kirlia.yaml
+++ b/Prima/281_Kirlia.yaml
@@ -1,0 +1,18 @@
+species: Kirlia
+setname: Prima
+item: [null]
+ability: [Synchronize,Trace]
+moves:
+    - [Psychic]
+    - [Hypnosis]
+    - [Future Sight]
+    - [Dream Eater]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/282_Gardevoir.yaml
+++ b/Prima/282_Gardevoir.yaml
@@ -1,0 +1,18 @@
+species: Gardevoir
+setname: Prima
+item: [null]
+ability: [Synchronize,Trace]
+moves:
+    - [Healing Wish]
+    - [Psychic]
+    - [Hypnosis]
+    - [Dream Eater]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/283_Surskit.yaml
+++ b/Prima/283_Surskit.yaml
@@ -1,0 +1,18 @@
+species: Surskit
+setname: Prima
+item: [null]
+ability: [Swift Swim]
+moves:
+    - [Rain Dance]
+    - [Signal Beam]
+    - [Bubble Beam]
+    - [Ice Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/284_Masquerain.yaml
+++ b/Prima/284_Masquerain.yaml
@@ -1,0 +1,18 @@
+species: Masquerain
+setname: Prima
+item: [null]
+ability: [Intimidate]
+moves:
+    - [Air Slash]
+    - [Silver Wind]
+    - [Roost]
+    - [Bug Buzz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/285_Shroomish.yaml
+++ b/Prima/285_Shroomish.yaml
@@ -1,0 +1,18 @@
+species: Shroomish
+setname: Prima
+item: [null]
+ability: [Effect Spore,Poison Heal]
+moves:
+    - [Spore]
+    - [Solar Beam]
+    - [Bullet seed]
+    - [Leech Seed]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/286_Breloom.yaml
+++ b/Prima/286_Breloom.yaml
@@ -1,0 +1,18 @@
+species: Breloom
+setname: Prima
+item: [null]
+ability: [Effect Spore,Poison Heal]
+moves:
+    - [Focus Blast]
+    - [Solar Beam]
+    - [Bullet seed]
+    - [Dynamic Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/287_Slakoth.yaml
+++ b/Prima/287_Slakoth.yaml
@@ -1,0 +1,18 @@
+species: Slakoth
+setname: Prima
+item: [null]
+ability: [Truant]
+moves:
+    - [Counter]
+    - [Flail]
+    - [Feint Attack]
+    - [Covet]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/288_Vigoroth.yaml
+++ b/Prima/288_Vigoroth.yaml
@@ -1,0 +1,18 @@
+species: Vigoroth
+setname: Prima
+item: [null]
+ability: [Vital Spirit]
+moves:
+    - [Focus Punch]
+    - [Reversal]
+    - [Slash]
+    - [Uproar]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/289_Slaking.yaml
+++ b/Prima/289_Slaking.yaml
@@ -1,0 +1,18 @@
+species: Slaking
+setname: Prima
+item: [null]
+ability: [Truant]
+moves:
+    - [Hammer Arm]
+    - [Swagger]
+    - [punishment]
+    - [Feint Attack]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/290_Nincada.yaml
+++ b/Prima/290_Nincada.yaml
@@ -1,0 +1,18 @@
+species: Nincada
+setname: Prima
+item: [null]
+ability: [Compund Eyes]
+moves:
+    - [Dig]
+    - [Solar Beam]
+    - [Bug Buzz]
+    - [Metal Claw]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/291_Ninjask.yaml
+++ b/Prima/291_Ninjask.yaml
@@ -1,0 +1,18 @@
+species: Ninjask
+setname: Prima
+item: [null]
+ability: [Speed Boost]
+moves:
+    - [Giga impact]
+    - [X-Scissor]
+    - [Aerial Ace]
+    - [Toxic]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/292_Shedinja.yaml
+++ b/Prima/292_Shedinja.yaml
@@ -1,0 +1,18 @@
+species: Shedinja
+setname: Prima
+item: [null]
+ability: [Wonder Guard]
+moves:
+    - [Heal Block]
+    - [X-Scissor]
+    - [Shadow Ball]
+    - [Sand Attack]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/293_Whismur.yaml
+++ b/Prima/293_Whismur.yaml
@@ -1,0 +1,18 @@
+species: Whismur
+setname: Prima
+item: [null]
+ability: [Sound Proof]
+moves:
+    - [Astonish]
+    - [Uproar]
+    - [Hyper Voice]
+    - [Stomp]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/294_Loudred.yaml
+++ b/Prima/294_Loudred.yaml
@@ -1,0 +1,18 @@
+species: Loudred
+setname: Prima
+item: [null]
+ability: [Soundproof]
+moves:
+    - [Bite]
+    - [Uproar]
+    - [Hyper Voice]
+    - [Stomp]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/295_Exploud.yaml
+++ b/Prima/295_Exploud.yaml
@@ -1,0 +1,18 @@
+species: Exploud
+setname: Prima
+item: [null]
+ability: [Sound Proof]
+moves:
+    - [Thunder Fang]
+    - [Ice Fang]
+    - [Hyper Beam]
+    - [Fire Fang]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/296_Makuhita.yaml
+++ b/Prima/296_Makuhita.yaml
@@ -1,0 +1,18 @@
+species: Makuhita
+setname: Prima
+item: [null]
+ability: [Guts,Thick Fat]
+moves:
+    - [Close Combat]
+    - [Focus Energy]
+    - [Seismic Toss]
+    - [Force Palm]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/297_Hariyama.yaml
+++ b/Prima/297_Hariyama.yaml
@@ -1,0 +1,18 @@
+species: Hariyama
+setname: Prima
+item: [null]
+ability: [Guts,Thick Fat]
+moves:
+    - [Close Combat]
+    - [Focus Energy]
+    - [Focus Punch]
+    - [Reversal]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/298_Azurill.yaml
+++ b/Prima/298_Azurill.yaml
@@ -1,0 +1,18 @@
+species: Azurill
+setname: Prima
+item: [null]
+ability: [Thick Fat,Huge Power]
+moves:
+    - [Charm]
+    - [Encore]
+    - [Slam]
+    - [Water Gun]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/299_Nosepass.yaml
+++ b/Prima/299_Nosepass.yaml
@@ -1,0 +1,18 @@
+species: Nosepass
+setname: Prima
+item: [null]
+ability: [Sturdy,Magnet Pull]
+moves:
+    - [Stone Edge]
+    - [Earth Power]
+    - [Explosion]
+    - [Zap Cannon]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/300_Skitty.yaml
+++ b/Prima/300_Skitty.yaml
@@ -1,0 +1,18 @@
+species: Skitty
+setname: Prima
+item: [null]
+ability: [Cute Charm,Normalize]
+moves:
+    - [Double-Edge]
+    - [Feint Attack]
+    - [Fake out]
+    - [Wake-up Slap]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/301_Delcatty.yaml
+++ b/Prima/301_Delcatty.yaml
@@ -1,0 +1,18 @@
+species: Delcatty
+setname: Prima
+item: [null]
+ability: [Cute Charm,Normalize]
+moves:
+    - [Fake Out]
+    - [Night Slash]
+    - [Shadow Claw]
+    - [Power Gem]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/302_Sableye.yaml
+++ b/Prima/302_Sableye.yaml
@@ -1,0 +1,18 @@
+species: Sableye
+setname: Prima
+item: [null]
+ability: [Keen Eye,Stall]
+moves:
+    - [Shadow Claw]
+    - [Shadow Ball]
+    - [Feint Attack]
+    - [Night Shade]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/303_Mawile.yaml
+++ b/Prima/303_Mawile.yaml
@@ -1,0 +1,18 @@
+species: Mawile
+setname: Prima
+item: [null]
+ability: [Hyper Cutter,Intimidate]
+moves:
+    - [iron Head]
+    - [Fake Tears]
+    - [Tickle]
+    - [Taunt]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/304_Aron.yaml
+++ b/Prima/304_Aron.yaml
@@ -1,0 +1,18 @@
+species: Aron
+setname: Prima
+item: [null]
+ability: [Sturdy,Rock Head]
+moves:
+    - [Iron Head]
+    - [Double-Edge]
+    - [Iron Defense]
+    - [Metal Burst]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/305_Lairon.yaml
+++ b/Prima/305_Lairon.yaml
@@ -1,0 +1,18 @@
+species: Lairon
+setname: Prima
+item: [null]
+ability: [Sturdy,Rock Head]
+moves:
+    - [Metal Sound]
+    - [Double-Edge]
+    - [Stone Edge]
+    - [Metal Burst]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/306_Aggron.yaml
+++ b/Prima/306_Aggron.yaml
@@ -1,0 +1,18 @@
+species: Aggron
+setname: Prima
+item: [null]
+ability: [Sturdy,Rock Head]
+moves:
+    - [Iron Tail]
+    - [Double-Edge]
+    - [Stone edge]
+    - [Metal Burst]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/307_Meditite.yaml
+++ b/Prima/307_Meditite.yaml
@@ -1,0 +1,18 @@
+species: Meditite
+setname: Prima
+item: [null]
+ability: [Pure Power]
+moves:
+    - [Psychic]
+    - [Recover]
+    - [High Jump Kick]
+    - [Dynamic Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/308_Medicham.yaml
+++ b/Prima/308_Medicham.yaml
@@ -1,0 +1,18 @@
+species: Medicham
+setname: Prima
+item: [null]
+ability: [Pure Power]
+moves:
+    - [Focus Punch]
+    - [Psychic]
+    - [Recover]
+    - [High Jump Kick]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/309_Electrike.yaml
+++ b/Prima/309_Electrike.yaml
@@ -1,0 +1,18 @@
+species: Electrike
+setname: Prima
+item: [null]
+ability: [Static,Lightningrod]
+moves:
+    - [Thunder Fang]
+    - [Ice Fang]
+    - [Thunder Wave]
+    - [Discharge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/310_Manectric.yaml
+++ b/Prima/310_Manectric.yaml
@@ -1,0 +1,18 @@
+species: Manectric
+setname: Prima
+item: [null]
+ability: [Static,Lightningrod]
+moves:
+    - [Overheat]
+    - [Thunder]
+    - [Charge]
+    - [Fire Fang]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/311_Plusle.yaml
+++ b/Prima/311_Plusle.yaml
@@ -1,0 +1,18 @@
+species: Plusle
+setname: Prima
+item: [null]
+ability: [Plus]
+moves:
+    - [Thunder]
+    - [HelpingHand]
+    - [Last Resort]
+    - [Nasty Plot]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/312_Minun.yaml
+++ b/Prima/312_Minun.yaml
@@ -1,0 +1,18 @@
+species: Minun
+setname: Prima
+item: [null]
+ability: [Minus]
+moves:
+    - [Thunder]
+    - [Trump card]
+    - [Helping Hand]
+    - [Nasty Plot]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/313_Volbeat.yaml
+++ b/Prima/313_Volbeat.yaml
@@ -1,0 +1,18 @@
+species: Volbeat
+setname: Prima
+item: [null]
+ability: [Illuminate,Swarm]
+moves:
+    - [Giga Drain]
+    - [Zen Headbutt]
+    - [Trick]
+    - [Bug Buzz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/314_Illumise.yaml
+++ b/Prima/314_Illumise.yaml
@@ -1,0 +1,18 @@
+species: Illumise
+setname: Prima
+item: [null]
+ability: [Oblivious,Tinted Lens]
+moves:
+    - [Silver Wind]
+    - [Zen Headbutt]
+    - [U Turn]
+    - [Bug Buzz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/315_Roselia.yaml
+++ b/Prima/315_Roselia.yaml
@@ -1,0 +1,18 @@
+species: Roselia
+setname: Prima
+item: [null]
+ability: [Natural Cure,Poison Point]
+moves:
+    - [Giga  Drain]
+    - [Toxic]
+    - [Sludge Bomb]
+    - [Leaf Storm]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/316_Gulpin.yaml
+++ b/Prima/316_Gulpin.yaml
@@ -1,0 +1,18 @@
+species: Gulpin
+setname: Prima
+item: [null]
+ability: [Liquid Ooze,Sticky Hold]
+moves:
+    - [Wring Out]
+    - [Gunk Shot]
+    - [Toxic]
+    - [Sludge Bomb]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/317_Swalot.yaml
+++ b/Prima/317_Swalot.yaml
@@ -1,0 +1,18 @@
+species: Swalot
+setname: Prima
+item: [null]
+ability: [Liquid Ooze,Sticky Hold]
+moves:
+    - [ Wring Out]
+    - [Gunk Shot]
+    - [Body Slam]
+    - [Sludge Bomb]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/318_Carvanha.yaml
+++ b/Prima/318_Carvanha.yaml
@@ -1,0 +1,18 @@
+species: Carvanha
+setname: Prima
+item: [null]
+ability: [Rough Skin]
+moves:
+    - [Take Down]
+    - [Surf]
+    - [Hydro Pump]
+    - [Blizzard]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/319_Sharpedo.yaml
+++ b/Prima/319_Sharpedo.yaml
@@ -1,0 +1,18 @@
+species: Sharpedo
+setname: Prima
+item: [null]
+ability: [Rough Skin]
+moves:
+    - [Night Slash]
+    - [Hyper Beam]
+    - [Blizzard]
+    - [Skull Bash]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/320_Wailmer.yaml
+++ b/Prima/320_Wailmer.yaml
@@ -1,0 +1,18 @@
+species: Wailmer
+setname: Prima
+item: [null]
+ability: [Water Veil,Oblivious]
+moves:
+    - [Astonish]
+    - [Water Spout]
+    - [Dive]
+    - [Water Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/321_Wailord.yaml
+++ b/Prima/321_Wailord.yaml
@@ -1,0 +1,18 @@
+species: Wailord
+setname: Prima
+item: [null]
+ability: [Water Veil,Oblivious]
+moves:
+    - [Water Spout]
+    - [Dive]
+    - [Bounce]
+    - [Hydro Pump]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/322_Numel.yaml
+++ b/Prima/322_Numel.yaml
@@ -1,0 +1,18 @@
+species: Numel
+setname: Prima
+item: [null]
+ability: [Oblivious,Simple]
+moves:
+    - [Flamethrower]
+    - [Double-edge]
+    - [Lava Plume]
+    - [Heat wave]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/323_Camerupt.yaml
+++ b/Prima/323_Camerupt.yaml
@@ -1,0 +1,18 @@
+species: Camerupt
+setname: Prima
+item: [null]
+ability: [Oblivious,Simple]
+moves:
+    - [Earthquake]
+    - [Fissure]
+    - [Lava Plume]
+    - [Eruption]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/324_Torkoal.yaml
+++ b/Prima/324_Torkoal.yaml
@@ -1,0 +1,18 @@
+species: Torkoal
+setname: Prima
+item: [null]
+ability: [White Smoke]
+moves:
+    - [Heat Wave]
+    - [Lava Plume]
+    - [Eruption]
+    - [Protect]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/325_Spoink.yaml
+++ b/Prima/325_Spoink.yaml
@@ -1,0 +1,18 @@
+species: Spoink
+setname: Prima
+item: [null]
+ability: [Thick Fat,Own Tempo]
+moves:
+    - [Zen Headbutt]
+    - [Extrasensory]
+    - [Bounce]
+    - [Future Sight]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/326_Grumpig.yaml
+++ b/Prima/326_Grumpig.yaml
@@ -1,0 +1,18 @@
+species: Grumpig
+setname: Prima
+item: [null]
+ability: [Thick Fat,Own Tempo]
+moves:
+    - [Psychic]
+    - [Zen Headbutt]
+    - [Bounce]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/327_Spinda.yaml
+++ b/Prima/327_Spinda.yaml
@@ -1,0 +1,18 @@
+species: Spinda
+setname: Prima
+item: [null]
+ability: [Own Tempo,Tangled Feet]
+moves:
+    - [Thrash]
+    - [Psybeam]
+    - [Sucker Punch]
+    - [Teeter Dance]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/328_Trapinch.yaml
+++ b/Prima/328_Trapinch.yaml
@@ -1,0 +1,18 @@
+species: Trapinch
+setname: Prima
+item: [null]
+ability: [Hyper cutter,Arena Trap]
+moves:
+    - [Dig]
+    - [Fissure]
+    - [Sand attack]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/329_Vibrava.yaml
+++ b/Prima/329_Vibrava.yaml
@@ -1,0 +1,18 @@
+species: Vibrava
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Sand Attack]
+    - [Hyper Beam]
+    - [Draco Meteor]
+    - [Dragon Breath]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/330_Flygon.yaml
+++ b/Prima/330_Flygon.yaml
@@ -1,0 +1,18 @@
+species: Flygon
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Sand tomb]
+    - [Dragon claw]
+    - [Hyper Beam]
+    - [Draco Meteor]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/331_Cacnea.yaml
+++ b/Prima/331_Cacnea.yaml
@@ -1,0 +1,18 @@
+species: Cacnea
+setname: Prima
+item: [null]
+ability: [Sand veil]
+moves:
+    - [Sand Attack]
+    - [Grass Whistle]
+    - [Sandstorm]
+    - [Solar Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/332_Cacturne.yaml
+++ b/Prima/332_Cacturne.yaml
@@ -1,0 +1,18 @@
+species: Cacturne
+setname: Prima
+item: [null]
+ability: [Sand Veil]
+moves:
+    - [Sandstorm]
+    - [Dark Pulse]
+    - [Twinneedle]
+    - [Destiny Bond]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/333_Swablu.yaml
+++ b/Prima/333_Swablu.yaml
@@ -1,0 +1,18 @@
+species: Swablu
+setname: Prima
+item: [null]
+ability: [Natural Cure]
+moves:
+    - [Fly]
+    - [Take Down]
+    - [Dragon Rush]
+    - [Perish Song]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/334_Altaria.yaml
+++ b/Prima/334_Altaria.yaml
@@ -1,0 +1,18 @@
+species: Altaria
+setname: Prima
+item: [null]
+ability: [Natural Cure]
+moves:
+    - [Sky Attack]
+    - [Hyper Beam]
+    - [Perish Song]
+    - [Dragon Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/335_Zangoose.yaml
+++ b/Prima/335_Zangoose.yaml
@@ -1,0 +1,18 @@
+species: Zangoose
+setname: Prima
+item: [null]
+ability: [Immunity]
+moves:
+    - [Close Combat]
+    - [X-scissor]
+    - [Scratch]
+    - [Crush Claw]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/336_Seviper.yaml
+++ b/Prima/336_Seviper.yaml
@@ -1,0 +1,18 @@
+species: Seviper
+setname: Prima
+item: [null]
+ability: [Shed Skin]
+moves:
+    - [Lick]
+    - [Wring Out]
+    - [Poison Jab]
+    - [Poison Fang]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/337_Lunatone.yaml
+++ b/Prima/337_Lunatone.yaml
@@ -1,0 +1,18 @@
+species: Lunatone
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Psychic]
+    - [Hypnosis]
+    - [Stone Edge]
+    - [Explosion]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/338_Solrock.yaml
+++ b/Prima/338_Solrock.yaml
@@ -1,0 +1,18 @@
+species: Solrock
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Rock Slide]
+    - [Psychic]
+    - [Explosion]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/339_Barboach.yaml
+++ b/Prima/339_Barboach.yaml
@@ -1,0 +1,18 @@
+species: Barboach
+setname: Prima
+item: [null]
+ability: [Oblivious,Anticipation]
+moves:
+    - [Aqua Tail]
+    - [Fissure]
+    - [Mud Sport]
+    - [Water Sport]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/340_Whiscash.yaml
+++ b/Prima/340_Whiscash.yaml
@@ -1,0 +1,18 @@
+species: Whiscash
+setname: Prima
+item: [null]
+ability: [Oblivious,Anticipation]
+moves:
+    - [Earthquake]
+    - [Fissure]
+    - [Magnitude]
+    - [Water Sport]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/341_Corphish.yaml
+++ b/Prima/341_Corphish.yaml
@@ -1,0 +1,18 @@
+species: Corphish
+setname: Prima
+item: [null]
+ability: [Hyper Cutter,Shell Armor]
+moves:
+    - [BubbleBeam]
+    - [Crunch]
+    - [Crabhammer]
+    - [Taunt]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/342_Crawdaunt.yaml
+++ b/Prima/342_Crawdaunt.yaml
@@ -1,0 +1,18 @@
+species: Crawdaunt
+setname: Prima
+item: [null]
+ability: [Hyper Cutter,Shell Armor]
+moves:
+    - [Crunch]
+    - [Crabhammer]
+    - [Night Slash]
+    - [Guillotine]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/343_Baltoy.yaml
+++ b/Prima/343_Baltoy.yaml
@@ -1,0 +1,18 @@
+species: Baltoy
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Dig]
+    - [Heal Block]
+    - [Psychic]
+    - [Explosion]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/344_Claydol.yaml
+++ b/Prima/344_Claydol.yaml
@@ -1,0 +1,18 @@
+species: Claydol
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Heal Block]
+    - [Rapid Spin]
+    - [Earth Power]
+    - [Explosion]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/345_Lileep.yaml
+++ b/Prima/345_Lileep.yaml
@@ -1,0 +1,18 @@
+species: Lileep
+setname: Prima
+item: [null]
+ability: [Suction Cups]
+moves:
+    - [Rock Slide]
+    - [Energy Ball]
+    - [Ancient Power]
+    - [Wring Out]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/346_Cradily.yaml
+++ b/Prima/346_Cradily.yaml
@@ -1,0 +1,18 @@
+species: Cradily
+setname: Prima
+item: [null]
+ability: [Suction Cups]
+moves:
+    - [Energy Ball]
+    - [Giga Impact]
+    - [Ancient Power]
+    - [Wring Out]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/347_Anorith.yaml
+++ b/Prima/347_Anorith.yaml
@@ -1,0 +1,18 @@
+species: Anorith
+setname: Prima
+item: [null]
+ability: [Battle Armor]
+moves:
+    - [Ancient Power]
+    - [X-Scissor]
+    - [Knock Off]
+    - [Rock Blast]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/348_Armaldo.yaml
+++ b/Prima/348_Armaldo.yaml
@@ -1,0 +1,18 @@
+species: Armaldo
+setname: Prima
+item: [null]
+ability: [Battle Armor]
+moves:
+    - [Slash]
+    - [X-Scissor]
+    - [Crush Claw]
+    - [Rock Blast]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/349_Feebas.yaml
+++ b/Prima/349_Feebas.yaml
@@ -1,0 +1,18 @@
+species: Feebas
+setname: Prima
+item: [null]
+ability: [Swift Swim]
+moves:
+    - [Hypnosis]
+    - [Flail]
+    - [Surf]
+    - [Splash]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/350_Milotic.yaml
+++ b/Prima/350_Milotic.yaml
@@ -1,0 +1,18 @@
+species: Milotic
+setname: Prima
+item: [null]
+ability: [Marvel Scale]
+moves:
+    - [Aqua Tail]
+    - [Aqua Ring]
+    - [Safeguard]
+    - [Hydro Pump]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/351_Castform.yaml
+++ b/Prima/351_Castform.yaml
@@ -1,0 +1,18 @@
+species: Castform
+setname: Prima
+item: [null]
+ability: [Forecast]
+moves:
+    - [Weather Ball]
+    - [Rain Dance]
+    - [Hail]
+    - [Sunny Day]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/352_Kecleon.yaml
+++ b/Prima/352_Kecleon.yaml
@@ -1,0 +1,18 @@
+species: Kecleon
+setname: Prima
+item: [null]
+ability: [Color change]
+moves:
+    - [Slash]
+    - [AncientPower]
+    - [Thief]
+    - [Sucker Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/353_Shuppet.yaml
+++ b/Prima/353_Shuppet.yaml
@@ -1,0 +1,18 @@
+species: Shuppet
+setname: Prima
+item: [null]
+ability: [Insomnia,Frisk]
+moves:
+    - [Grudge]
+    - [Thunder]
+    - [Shadow Ball]
+    - [Sucker Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/354_Banette.yaml
+++ b/Prima/354_Banette.yaml
@@ -1,0 +1,18 @@
+species: Banette
+setname: Prima
+item: [null]
+ability: [Insomnia,Frisk]
+moves:
+    - [Grudge]
+    - [Shadow Ball]
+    - [Sucker Punch]
+    - [Giga Impact]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/355_Duskull.yaml
+++ b/Prima/355_Duskull.yaml
@@ -1,0 +1,18 @@
+species: Duskull
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Will-O-Wisp]
+    - [Grudge]
+    - [Payback]
+    - [Future Sight]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/356_Dusclops.yaml
+++ b/Prima/356_Dusclops.yaml
@@ -1,0 +1,18 @@
+species: Dusclops
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Will-O-Wisp]
+    - [Payback]
+    - [Bide]
+    - [Future Sight]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/357_Tropius.yaml
+++ b/Prima/357_Tropius.yaml
@@ -1,0 +1,18 @@
+species: Tropius
+setname: Prima
+item: [null]
+ability: [Chlorophyll,Solar Power]
+moves:
+    - [Air Slash]
+    - [Synthesis]
+    - [Sunny day]
+    - [SolarBeam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/358_Chimecho.yaml
+++ b/Prima/358_Chimecho.yaml
@@ -1,0 +1,18 @@
+species: Chimecho
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Healing Wish]
+    - [Hypnosis]
+    - [Extrasensory]
+    - [Double-Edge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/359_Absol.yaml
+++ b/Prima/359_Absol.yaml
@@ -1,0 +1,18 @@
+species: Absol
+setname: Prima
+item: [null]
+ability: [Pressure,Super Luck]
+moves:
+    - [Psycho Cut]
+    - [Double-Edge]
+    - [Hyper Beam]
+    - [Perish Song]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/360_Wynaut.yaml
+++ b/Prima/360_Wynaut.yaml
@@ -1,0 +1,18 @@
+species: Wynaut
+setname: Prima
+item: [null]
+ability: [Shadow Tag]
+moves:
+    - [Charm]
+    - [Counter]
+    - [Splash]
+    - [Destiny Bond]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/361_Snorunt.yaml
+++ b/Prima/361_Snorunt.yaml
@@ -1,0 +1,18 @@
+species: Snorunt
+setname: Prima
+item: [null]
+ability: [Inner Focus,Ice Body]
+moves:
+    - [Hail]
+    - [Crunch]
+    - [Ice Shard]
+    - [Blizzard]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/362_Glalie.yaml
+++ b/Prima/362_Glalie.yaml
@@ -1,0 +1,18 @@
+species: Glalie
+setname: Prima
+item: [null]
+ability: [Inner Focus,Ice Body]
+moves:
+    - [Hail]
+    - [Sheer Cold]
+    - [Blizzard]
+    - [Ice Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/363_Spheal.yaml
+++ b/Prima/363_Spheal.yaml
@@ -1,0 +1,18 @@
+species: Spheal
+setname: Prima
+item: [null]
+ability: [Thick Fat,Ice Body]
+moves:
+    - [Encore]
+    - [Sheer Cold]
+    - [Waterfall]
+    - [Blizzard]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/364_Sealeo.yaml
+++ b/Prima/364_Sealeo.yaml
@@ -1,0 +1,18 @@
+species: Sealeo
+setname: Prima
+item: [null]
+ability: [Thick Fat,Ice Body]
+moves:
+    - [Hail]
+    - [Sheer Cold]
+    - [Rest]
+    - [Blizzard]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/365_Walrein.yaml
+++ b/Prima/365_Walrein.yaml
@@ -1,0 +1,18 @@
+species: Walrein
+setname: Prima
+item: [null]
+ability: [Thick Fat,Ice Body]
+moves:
+    - [Hail]
+    - [Sheer Cold]
+    - [Waterfall]
+    - [Blizzard]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/366_Clamperl.yaml
+++ b/Prima/366_Clamperl.yaml
@@ -1,0 +1,18 @@
+species: Clamperl
+setname: Prima
+item: [null]
+ability: [Shell Armor]
+moves:
+    - [Whirlpool]
+    - [Mud Sport]
+    - [Surf]
+    - [Ice Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/367_Huntail.yaml
+++ b/Prima/367_Huntail.yaml
@@ -1,0 +1,18 @@
+species: Huntail
+setname: Prima
+item: [null]
+ability: [Swift Swim]
+moves:
+    - [Aqua Tail]
+    - [Crunch]
+    - [Surf]
+    - [Hydro Pump]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/368_Gorebyss.yaml
+++ b/Prima/368_Gorebyss.yaml
@@ -1,0 +1,18 @@
+species: Gorebyss
+setname: Prima
+item: [null]
+ability: [Swift Swim]
+moves:
+    - [Aqua Tail]
+    - [Psychic]
+    - [Dive]
+    - [Hydro Pump]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/369_Relicanth.yaml
+++ b/Prima/369_Relicanth.yaml
@@ -1,0 +1,18 @@
+species: Relicanth
+setname: Prima
+item: [null]
+ability: [Swift Swim,Rock Head]
+moves:
+    - [Double-Edge]
+    - [Dive]
+    - [Hydro Pump]
+    - [Head Smash]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/370_Luvdisc.yaml
+++ b/Prima/370_Luvdisc.yaml
@@ -1,0 +1,18 @@
+species: Luvdisc
+setname: Prima
+item: [null]
+ability: [Swift Swim]
+moves:
+    - [Sweet Kiss]
+    - [Flail]
+    - [Water Pulse]
+    - [Take Down]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/371_Bagon.yaml
+++ b/Prima/371_Bagon.yaml
@@ -1,0 +1,18 @@
+species: Bagon
+setname: Prima
+item: [null]
+ability: [Rock Head]
+moves:
+    - [Crunch]
+    - [Zen Headbutt]
+    - [Dragon Claw]
+    - [Draco Meteor]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/372_Shelgon.yaml
+++ b/Prima/372_Shelgon.yaml
@@ -1,0 +1,18 @@
+species: Shelgon
+setname: Prima
+item: [null]
+ability: [Rock Head]
+moves:
+    - [Zen Headbutt]
+    - [Double-Edge]
+    - [Dragon Claw]
+    - [Draco Meteor]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/373_Salamence.yaml
+++ b/Prima/373_Salamence.yaml
@@ -1,0 +1,18 @@
+species: Salamence
+setname: Prima
+item: [null]
+ability: [Intimidate]
+moves:
+    - [Fly]
+    - [Dragon Claw]
+    - [Draco Meteor]
+    - [Dragon Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/374_Beldum.yaml
+++ b/Prima/374_Beldum.yaml
@@ -1,0 +1,15 @@
+species: Beldum
+setname: Prima
+item: [null]
+ability: [Clear Body]
+moves:
+    - [Take Down]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/375_Metang.yaml
+++ b/Prima/375_Metang.yaml
@@ -1,0 +1,18 @@
+species: Metang
+setname: Prima
+item: [null]
+ability: [Clear Body]
+moves:
+    - [Meteor Mash]
+    - [Psychic]
+    - [Zen Headbutt]
+    - [Take Down]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/376_Metagross.yaml
+++ b/Prima/376_Metagross.yaml
@@ -1,0 +1,18 @@
+species: Metagross
+setname: Prima
+item: [null]
+ability: [Clear Body]
+moves:
+    - [Hammer Arm]
+    - [Meteor Mash]
+    - [Zen Headbutt]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/377_Regirock.yaml
+++ b/Prima/377_Regirock.yaml
@@ -1,0 +1,18 @@
+species: Regirock
+setname: Prima
+item: [null]
+ability: [Clear Body]
+moves:
+    - [Rock Throw]
+    - [Stone Edge]
+    - [Explosion]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/378_Regice.yaml
+++ b/Prima/378_Regice.yaml
@@ -1,0 +1,18 @@
+species: Regice
+setname: Prima
+item: [null]
+ability: [Clear Body]
+moves:
+    - [Explosion]
+    - [Curse]
+    - [Hyper Beam]
+    - [Ice Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/379_Registeel.yaml
+++ b/Prima/379_Registeel.yaml
@@ -1,0 +1,18 @@
+species: Registeel
+setname: Prima
+item: [null]
+ability: [Clear Body]
+moves:
+    - [Explosion]
+    - [Curse]
+    - [Hyper Beam]
+    - [Flash Cannon]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/380_Latias.yaml
+++ b/Prima/380_Latias.yaml
@@ -1,0 +1,18 @@
+species: Latias
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Psywave]
+    - [Zen Headbutt]
+    - [Draco Meteor]
+    - [Dragon Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/381_Latios.yaml
+++ b/Prima/381_Latios.yaml
@@ -1,0 +1,18 @@
+species: Latios
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Psywave]
+    - [Psychic]
+    - [Draco Meteor]
+    - [Dragon Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/382_Kyogre.yaml
+++ b/Prima/382_Kyogre.yaml
@@ -1,0 +1,18 @@
+species: Kyogre
+setname: Prima
+item: [null]
+ability: [Drizzle]
+moves:
+    - [Aqua Tail]
+    - [Water Spout]
+    - [Sheer Cold]
+    - [Body Slam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/383_Groudon.yaml
+++ b/Prima/383_Groudon.yaml
@@ -1,0 +1,18 @@
+species: Groudon
+setname: Prima
+item: [null]
+ability: [Drought]
+moves:
+    - [Earthquake]
+    - [Fissure]
+    - [Fire Blast]
+    - [Eruption]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/384_Rayquaza.yaml
+++ b/Prima/384_Rayquaza.yaml
@@ -1,0 +1,18 @@
+species: Rayquaza
+setname: Prima
+item: [null]
+ability: [Air Lock]
+moves:
+    - [Outrage]
+    - [Dragon Claw]
+    - [Hyper Beam]
+    - [Draco Meteor]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/385_Jirachi.yaml
+++ b/Prima/385_Jirachi.yaml
@@ -1,0 +1,18 @@
+species: Jirachi
+setname: Prima
+item: [null]
+ability: [Serene Grace]
+moves:
+    - [Psychic]
+    - [Last Resort]
+    - [Healing Wish]
+    - [Doom Desire]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/386_Deoxys.yaml
+++ b/Prima/386_Deoxys.yaml
@@ -1,0 +1,18 @@
+species: Deoxys
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Psychic]
+    - [Psycho Boost]
+    - [Zen Headbutt]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/387_Turtwig.yaml
+++ b/Prima/387_Turtwig.yaml
@@ -1,0 +1,18 @@
+species: Turtwig
+setname: Prima
+item: [null]
+ability: [Overgrow]
+moves:
+    - [Protect]
+    - [Crunch]
+    - [Giga Drain]
+    - [Leaf Storm]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/388_Grotle.yaml
+++ b/Prima/388_Grotle.yaml
@@ -1,0 +1,18 @@
+species: Grotle
+setname: Prima
+item: [null]
+ability: [Overgrow]
+moves:
+    - [Sunny Day]
+    - [Giga Drain]
+    - [SolarBeam]
+    - [Leaf Storm]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/389_Torterra.yaml
+++ b/Prima/389_Torterra.yaml
@@ -1,0 +1,18 @@
+species: Torterra
+setname: Prima
+item: [null]
+ability: [Overgrow]
+moves:
+    - [Protect]
+    - [Giga Drain]
+    - [Earthquake]
+    - [Leaf Storm]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/390_Chimchar.yaml
+++ b/Prima/390_Chimchar.yaml
@@ -1,0 +1,18 @@
+species: Chimchar
+setname: Prima
+item: [null]
+ability: [Blaze]
+moves:
+    - [Flame Wheel]
+    - [Facade]
+    - [Blaze Kick]
+    - [Fire Spin]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/391_Monferno.yaml
+++ b/Prima/391_Monferno.yaml
@@ -1,0 +1,18 @@
+species: Monferno
+setname: Prima
+item: [null]
+ability: [Blaze]
+moves:
+    - [Close Combat]
+    - [Flame Wheel]
+    - [Flare Blitz]
+    - [Fire Spin]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/392_Infernape.yaml
+++ b/Prima/392_Infernape.yaml
@@ -1,0 +1,18 @@
+species: Infernape
+setname: Prima
+item: [null]
+ability: [Blaze]
+moves:
+    - [Close Combat]
+    - [Punishment]
+    - [Flare Blitz]
+    - [Fire Spin]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/393_Piplup.yaml
+++ b/Prima/393_Piplup.yaml
@@ -1,0 +1,18 @@
+species: Piplup
+setname: Prima
+item: [null]
+ability: [Torrent]
+moves:
+    - [Whirlpool]
+    - [Brine]
+    - [Hydro Pump]
+    - [Fury Attack]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/394_Prinplup.yaml
+++ b/Prima/394_Prinplup.yaml
@@ -1,0 +1,18 @@
+species: Prinplup
+setname: Prima
+item: [null]
+ability: [Torrent]
+moves:
+    - [Bide]
+    - [Brine]
+    - [BubbleBeam]
+    - [Water Sport]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/395_Empoleon.yaml
+++ b/Prima/395_Empoleon.yaml
@@ -1,0 +1,18 @@
+species: Empoleon
+setname: Prima
+item: [null]
+ability: [Torrent]
+moves:
+    - [Brine]
+    - [Drill Peck]
+    - [Hydro Pump]
+    - [Metal Claw]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/396_Starly.yaml
+++ b/Prima/396_Starly.yaml
@@ -1,0 +1,18 @@
+species: Starly
+setname: Prima
+item: [null]
+ability: [Keen Eye]
+moves:
+    - [Double-Edge]
+    - [Wing Attack]
+    - [Aerial Ace]
+    - [Brave Bird]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/397_Staravia.yaml
+++ b/Prima/397_Staravia.yaml
@@ -1,0 +1,18 @@
+species: Staravia
+setname: Prima
+item: [null]
+ability: [Intimidate]
+moves:
+    - [Fly]
+    - [Aerial Ace]
+    - [Take Down]
+    - [Brave Bird]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/398_Staraptor.yaml
+++ b/Prima/398_Staraptor.yaml
@@ -1,0 +1,18 @@
+species: Staraptor
+setname: Prima
+item: [null]
+ability: [Intimidate]
+moves:
+    - [Close Combat]
+    - [Giga Impact]
+    - [Take Down]
+    - [Brave Bird]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/399_Bidoof.yaml
+++ b/Prima/399_Bidoof.yaml
@@ -1,0 +1,18 @@
+species: Bidoof
+setname: Prima
+item: [null]
+ability: [Simple,Unaware]
+moves:
+    - [Super Fang]
+    - [Take Down]
+    - [Super Power]
+    - [Hyper Fang]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/400_Bibarel.yaml
+++ b/Prima/400_Bibarel.yaml
@@ -1,0 +1,18 @@
+species: Bibarel
+setname: Prima
+item: [null]
+ability: [Simple,Unaware]
+moves:
+    - [Super Fang]
+    - [Rollout]
+    - [Super Power]
+    - [Hyper Fang]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/401_Kricketot.yaml
+++ b/Prima/401_Kricketot.yaml
@@ -1,0 +1,16 @@
+species: Kricketot
+setname: Prima
+item: [null]
+ability: [Shed Skin]
+moves:
+    - [Growl]
+    - [Bide]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/402_Kricketune.yaml
+++ b/Prima/402_Kricketune.yaml
@@ -1,0 +1,18 @@
+species: Kricketune
+setname: Prima
+item: [null]
+ability: [Swarm]
+moves:
+    - [Giga Impact]
+    - [X-Scissor]
+    - [Perish Song]
+    - [Bug Buzz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/403_Shinx.yaml
+++ b/Prima/403_Shinx.yaml
@@ -1,0 +1,18 @@
+species: Shinx
+setname: Prima
+item: [null]
+ability: [Rivalry,Intimidate]
+moves:
+    - [Rain Dance]
+    - [Thunder]
+    - [Quick Attack]
+    - [Discharge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/404_Luxio.yaml
+++ b/Prima/404_Luxio.yaml
@@ -1,0 +1,18 @@
+species: Luxio
+setname: Prima
+item: [null]
+ability: [Rivalry,Intimidate]
+moves:
+    - [Thunder]
+    - [Thunder Fang]
+    - [Charge Beam]
+    - [Discharge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/405_Luxray.yaml
+++ b/Prima/405_Luxray.yaml
@@ -1,0 +1,18 @@
+species: Luxray
+setname: Prima
+item: [null]
+ability: [Rivalry,Intimidate]
+moves:
+    - [Thunder]
+    - [Giga Impact]
+    - [Charge]
+    - [Discharge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/406_Budew.yaml
+++ b/Prima/406_Budew.yaml
@@ -1,0 +1,18 @@
+species: Budew
+setname: Prima
+item: [null]
+ability: [Natural Cure,Poison Point]
+moves:
+    - [Toxic]
+    - [Solarbeam]
+    - [Leaf Storm]
+    - [Giga Drain]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/407_Roserade.yaml
+++ b/Prima/407_Roserade.yaml
@@ -1,0 +1,18 @@
+species: Roserade
+setname: Prima
+item: [null]
+ability: [Natural Cure,Poison Point]
+moves:
+    - [Giga Drain]
+    - [Solarbeam]
+    - [Toxic]
+    - [Sludge Bomb]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/408_Cranidos.yaml
+++ b/Prima/408_Cranidos.yaml
@@ -1,0 +1,18 @@
+species: Cranidos
+setname: Prima
+item: [null]
+ability: [Mold Breaker]
+moves:
+    - [AncientPower]
+    - [Headbutt]
+    - [Take Down]
+    - [Head Smash]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/409_Rampardos.yaml
+++ b/Prima/409_Rampardos.yaml
@@ -1,0 +1,18 @@
+species: Rampardos
+setname: Prima
+item: [null]
+ability: [Mold Breaker]
+moves:
+    - [Zen Headbutt]
+    - [Stone Edge]
+    - [Surf]
+    - [Head Smash]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/410_Shieldon.yaml
+++ b/Prima/410_Shieldon.yaml
@@ -1,0 +1,18 @@
+species: Shieldon
+setname: Prima
+item: [null]
+ability: [Sturdy]
+moves:
+    - [Iron Head]
+    - [Iron Defense]
+    - [Metal Burst]
+    - [Rock Blast]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/411_Bastiodon.yaml
+++ b/Prima/411_Bastiodon.yaml
@@ -1,0 +1,18 @@
+species: Bastiodon
+setname: Prima
+item: [null]
+ability: [Sturdy]
+moves:
+    - [Iron Head]
+    - [AncientPower]
+    - [Hyper Beam]
+    - [Metal Burst]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/412_Burmy.yaml
+++ b/Prima/412_Burmy.yaml
@@ -1,0 +1,17 @@
+species: Burmy
+setname: Prima
+item: [null]
+ability: [Shed Skin]
+moves:
+    - [Tackle]
+    - [Protect]
+    - [Hidden Power]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/413_Wormadam.yaml
+++ b/Prima/413_Wormadam.yaml
@@ -1,0 +1,18 @@
+species: Wormadam
+setname: Prima
+item: [null]
+ability: [                          Anticipation]
+moves:
+    - [Grass Knot]
+    - [Psychic]
+    - [SolarBeam]
+    - [LeafStorm]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/414_Mothim.yaml
+++ b/Prima/414_Mothim.yaml
@@ -1,0 +1,18 @@
+species: Mothim
+setname: Prima
+item: [null]
+ability: [Swarm]
+moves:
+    - [Air Slash]
+    - [Silver Wind]
+    - [Psychic]
+    - [Bug Buzz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/415_Combee.yaml
+++ b/Prima/415_Combee.yaml
@@ -1,0 +1,16 @@
+species: Combee
+setname: Prima
+item: [null]
+ability: [Honey Gather]
+moves:
+    - [Sweet Scent]
+    - [Gust]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/416_Vespiquen.yaml
+++ b/Prima/416_Vespiquen.yaml
@@ -1,0 +1,18 @@
+species: Vespiquen
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Heal Order]
+    - [Attack Order]
+    - [Power Gem]
+    - [Defend Order]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/417_Pachirisu.yaml
+++ b/Prima/417_Pachirisu.yaml
@@ -1,0 +1,18 @@
+species: Pachirisu
+setname: Prima
+item: [null]
+ability: [Run Away,Pick Up]
+moves:
+    - [Thunder]
+    - [Flail]
+    - [Last Resort]
+    - [Discharge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/418_Buizel.yaml
+++ b/Prima/418_Buizel.yaml
@@ -1,0 +1,18 @@
+species: Buizel
+setname: Prima
+item: [null]
+ability: [Swift Swim]
+moves:
+    - [Aqua Jet]
+    - [Razor Wind]
+    - [Swift]
+    - [Water Sport]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/419_Floatzel.yaml
+++ b/Prima/419_Floatzel.yaml
@@ -1,0 +1,18 @@
+species: Floatzel
+setname: Prima
+item: [null]
+ability: [Swift Swim]
+moves:
+    - [Whirlpool]
+    - [Razor Wind]
+    - [Crunch]
+    - [Swift]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/420_Cherubi.yaml
+++ b/Prima/420_Cherubi.yaml
@@ -1,0 +1,18 @@
+species: Cherubi
+setname: Prima
+item: [null]
+ability: [Chlorophyll]
+moves:
+    - [Lucky Chant]
+    - [Giga Drain]
+    - [Solar Beam]
+    - [Sunny Day]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/421_Cherrim.yaml
+++ b/Prima/421_Cherrim.yaml
@@ -1,0 +1,18 @@
+species: Cherrim
+setname: Prima
+item: [null]
+ability: [Flower Gift]
+moves:
+    - [Giga Drain]
+    - [SolarBeam]
+    - [Take Down]
+    - [Sunny Day]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/422_Shellos.yaml
+++ b/Prima/422_Shellos.yaml
@@ -1,0 +1,18 @@
+species: Shellos
+setname: Prima
+item: [null]
+ability: [Sticky Hold,Storm Drain]
+moves:
+    - [Rain Dance]
+    - [Muddy Water]
+    - [Surf]
+    - [Body Slam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/423_Gastrodon.yaml
+++ b/Prima/423_Gastrodon.yaml
@@ -1,0 +1,18 @@
+species: Gastrodon
+setname: Prima
+item: [null]
+ability: [Sticky Hold,Storm Drain]
+moves:
+    - [Recover]
+    - [Muddy Water]
+    - [Mud Bomb]
+    - [Surf]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/424_Ambipom.yaml
+++ b/Prima/424_Ambipom.yaml
@@ -1,0 +1,18 @@
+species: Ambipom
+setname: Prima
+item: [null]
+ability: [Technician,Pick Up]
+moves:
+    - [Astonish]
+    - [Agility]
+    - [Double Hit]
+    - [Last Resort]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/425_Drifloon.yaml
+++ b/Prima/425_Drifloon.yaml
@@ -1,0 +1,18 @@
+species: Drifloon
+setname: Prima
+item: [null]
+ability: [Aftermath,Unburden]
+moves:
+    - [Ominous Wind]
+    - [Gust]
+    - [Shadow Ball]
+    - [Explosion]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/426_Drifblim.yaml
+++ b/Prima/426_Drifblim.yaml
@@ -1,0 +1,18 @@
+species: Drifblim
+setname: Prima
+item: [null]
+ability: [Aftermath,Unburden]
+moves:
+    - [Omnious Wind]
+    - [Shadow Ball]
+    - [Fly]
+    - [Explosion]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/427_Buneary.yaml
+++ b/Prima/427_Buneary.yaml
@@ -1,0 +1,18 @@
+species: Buneary
+setname: Prima
+item: [null]
+ability: [Run Away,Klutz]
+moves:
+    - [Quick Attack]
+    - [Jump Kick]
+    - [Defense Curl]
+    - [Dizzy Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/428_Lopunny.yaml
+++ b/Prima/428_Lopunny.yaml
@@ -1,0 +1,18 @@
+species: Lopunny
+setname: Prima
+item: [null]
+ability: [Run Away,Klutz]
+moves:
+    - [Healing Wish]
+    - [Dizzy Punch]
+    - [Bounce]
+    - [Protect]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/429_Mismagius.yaml
+++ b/Prima/429_Mismagius.yaml
@@ -1,0 +1,18 @@
+species: Mismagius
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Giga Impact]
+    - [Psychic]
+    - [Shadow Ball]
+    - [Magical Leaf]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/430_Honchkrow.yaml
+++ b/Prima/430_Honchkrow.yaml
@@ -1,0 +1,18 @@
+species: Honchkrow
+setname: Prima
+item: [null]
+ability: [Insomnia,Super Luck]
+moves:
+    - [Dark Pulse]
+    - [Fly]
+    - [Hyper beam]
+    - [Roost]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/431_Glameow.yaml
+++ b/Prima/431_Glameow.yaml
@@ -1,0 +1,18 @@
+species: Glameow
+setname: Prima
+item: [null]
+ability: [Limber,Own Tempo]
+moves:
+    - [Slash]
+    - [Hypnosis]
+    - [Fake Out]
+    - [Sucker Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/432_Purugly.yaml
+++ b/Prima/432_Purugly.yaml
@@ -1,0 +1,18 @@
+species: Purugly
+setname: Prima
+item: [null]
+ability: [Limber,Own Tempo]
+moves:
+    - [Slash]
+    - [Hypnosis]
+    - [Feint Attack]
+    - [Body Slam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/433_Chingling.yaml
+++ b/Prima/433_Chingling.yaml
@@ -1,0 +1,18 @@
+species: Chingling
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Psychic]
+    - [Hypnosis]
+    - [Last Resort]
+    - [Dream Eater]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/434_Stunky.yaml
+++ b/Prima/434_Stunky.yaml
@@ -1,0 +1,18 @@
+species: Stunky
+setname: Prima
+item: [null]
+ability: [Stench,Aftermath]
+moves:
+    - [Slash]
+    - [Explosion]
+    - [Poison Gas]
+    - [Sludge Bomb]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/435_Skuntank.yaml
+++ b/Prima/435_Skuntank.yaml
@@ -1,0 +1,18 @@
+species: Skuntank
+setname: Prima
+item: [null]
+ability: [Stench,Aftermath]
+moves:
+    - [Memento]
+    - [Explosion]
+    - [Night Slash]
+    - [Poison Gas]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/436_Bronzor.yaml
+++ b/Prima/436_Bronzor.yaml
@@ -1,0 +1,18 @@
+species: Bronzor
+setname: Prima
+item: [null]
+ability: [Levitate,Heatproof]
+moves:
+    - [Heal Block]
+    - [Hypnosis]
+    - [Gyro Ball]
+    - [Extrasensory]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/437_Bronzong.yaml
+++ b/Prima/437_Bronzong.yaml
@@ -1,0 +1,18 @@
+species: Bronzong
+setname: Prima
+item: [null]
+ability: [Levitate,Heatproof]
+moves:
+    - [Hypnosis]
+    - [Gyro Ball]
+    - [Dream Eater]
+    - [Flash Cannon]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/438_Bonsly.yaml
+++ b/Prima/438_Bonsly.yaml
@@ -1,0 +1,18 @@
+species: Bonsly
+setname: Prima
+item: [null]
+ability: [Sturdy,Rock Head]
+moves:
+    - [Rock Slide]
+    - [Selfdestruct]
+    - [Double-Edge]
+    - [Mimic]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/439_Mime Jr..yaml
+++ b/Prima/439_Mime Jr..yaml
@@ -1,0 +1,18 @@
+species: Mime Jr.
+setname: Prima
+item: [null]
+ability: [SoundProof,Filter]
+moves:
+    - [Psychic]
+    - [Role Play]
+    - [Future Sight]
+    - [Mimic]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/440_Happiny.yaml
+++ b/Prima/440_Happiny.yaml
@@ -1,0 +1,18 @@
+species: Happiny
+setname: Prima
+item: [null]
+ability: [Natural Cure,Serene Grace]
+moves:
+    - [Charm]
+    - [Sweet Kiss]
+    - [Water Pulse]
+    - [Light Screen]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/441_Chatot.yaml
+++ b/Prima/441_Chatot.yaml
@@ -1,0 +1,18 @@
+species: Chatot
+setname: Prima
+item: [null]
+ability: [Keen Eye,Tangled Feet]
+moves:
+    - [Fly]
+    - [Aerial Ace]
+    - [Hyper Voice]
+    - [Mimic]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/442_Spiritomb.yaml
+++ b/Prima/442_Spiritomb.yaml
@@ -1,0 +1,18 @@
+species: Spiritomb
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Dark Pulse]
+    - [Ominous Wind]
+    - [Grudge]
+    - [Curse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/443_Gible.yaml
+++ b/Prima/443_Gible.yaml
@@ -1,0 +1,18 @@
+species: Gible
+setname: Prima
+item: [null]
+ability: [Sand Veil]
+moves:
+    - [Dragon Rush]
+    - [Dig]
+    - [Draco Meteor]
+    - [Dragon Rage]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/444_Gabite.yaml
+++ b/Prima/444_Gabite.yaml
@@ -1,0 +1,18 @@
+species: Gabite
+setname: Prima
+item: [null]
+ability: [Sand Veil]
+moves:
+    - [Dig]
+    - [Earthquake]
+    - [Dragon Rush]
+    - [Draco Meteor]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/445_Garchomp.yaml
+++ b/Prima/445_Garchomp.yaml
@@ -1,0 +1,18 @@
+species: Garchomp
+setname: Prima
+item: [null]
+ability: [Sand Veil]
+moves:
+    - [Dig]
+    - [Crunch]
+    - [Dragon Rush]
+    - [Draco Meteor]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/446_Munchlax.yaml
+++ b/Prima/446_Munchlax.yaml
@@ -1,0 +1,18 @@
+species: Munchlax
+setname: Prima
+item: [null]
+ability: [Pick Up,Thick Fat]
+moves:
+    - [Zen Headbutt]
+    - [Body Slam]
+    - [Rollout]
+    - [Facade]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/447_Riolu.yaml
+++ b/Prima/447_Riolu.yaml
@@ -1,0 +1,18 @@
+species: Riolu
+setname: Prima
+item: [null]
+ability: [Steadfast,Inner Focus]
+moves:
+    - [Counter]
+    - [Reversal]
+    - [Cross Chop]
+    - [Quick Attack]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/448_Lucario.yaml
+++ b/Prima/448_Lucario.yaml
@@ -1,0 +1,18 @@
+species: Lucario
+setname: Prima
+item: [null]
+ability: [Steadfast,Inner Focus]
+moves:
+    - [Dark Pulse]
+    - [Aura Sphere]
+    - [Protect]
+    - [Flash Cannon]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/449_Hippopotas.yaml
+++ b/Prima/449_Hippopotas.yaml
@@ -1,0 +1,18 @@
+species: Hippopotas
+setname: Prima
+item: [null]
+ability: [Sand Stream]
+moves:
+    - [Earthquake]
+    - [Fissure]
+    - [Take Down]
+    - [Body Slam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/450_Hippowdon.yaml
+++ b/Prima/450_Hippowdon.yaml
@@ -1,0 +1,18 @@
+species: Hippowdon
+setname: Prima
+item: [null]
+ability: [Sand Stream]
+moves:
+    - [Thunder Fang]
+    - [Earthquake]
+    - [Fissure]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/451_Skorupi.yaml
+++ b/Prima/451_Skorupi.yaml
@@ -1,0 +1,18 @@
+species: Skorupi
+setname: Prima
+item: [null]
+ability: [Battle Armor,Sniper]
+moves:
+    - [Crunch]
+    - [Cross Poison]
+    - [Poison Fang]
+    - [Toxic Spikes]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/452_Drapion.yaml
+++ b/Prima/452_Drapion.yaml
@@ -1,0 +1,18 @@
+species: Drapion
+setname: Prima
+item: [null]
+ability: [Battle Armor,Sniper]
+moves:
+    - [Dark Pulse]
+    - [Crunch]
+    - [Cross Poison]
+    - [Poison Fang]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/453_Croagunk.yaml
+++ b/Prima/453_Croagunk.yaml
@@ -1,0 +1,18 @@
+species: Croagunk
+setname: Prima
+item: [null]
+ability: [Antcipation,Dry Skin]
+moves:
+    - [Torment]
+    - [Taunt]
+    - [Poison Jab]
+    - [Sludge Bomb]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/454_Toxicroak.yaml
+++ b/Prima/454_Toxicroak.yaml
@@ -1,0 +1,18 @@
+species: Toxicroak
+setname: Prima
+item: [null]
+ability: [Antcipation,Dry Skin]
+moves:
+    - [Rain Dance]
+    - [Taunt]
+    - [Poison Jab]
+    - [Sludge Bomb]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/455_Carnivine.yaml
+++ b/Prima/455_Carnivine.yaml
@@ -1,0 +1,18 @@
+species: Carnivine
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Giga Drain]
+    - [Wring Out]
+    - [Power Whip]
+    - [Sludge Bomb]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/456_Finneon.yaml
+++ b/Prima/456_Finneon.yaml
@@ -1,0 +1,18 @@
+species: Finneon
+setname: Prima
+item: [null]
+ability: [Swift Swim,Storm Drain]
+moves:
+    - [Aqua Tail]
+    - [Whirlpool]
+    - [Safeguard]
+    - [Water Pulse]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/457_Lumineon.yaml
+++ b/Prima/457_Lumineon.yaml
@@ -1,0 +1,18 @@
+species: Lumineon
+setname: Prima
+item: [null]
+ability: [Swift Swim,Storm Drain]
+moves:
+    - [Whirlpool]
+    - [Silver Wind]
+    - [Bounce]
+    - [Surf]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/458_Mantyke.yaml
+++ b/Prima/458_Mantyke.yaml
@@ -1,0 +1,18 @@
+species: Mantyke
+setname: Prima
+item: [null]
+ability: [Swift Swim,Water Absorb]
+moves:
+    - [Rock Slide]
+    - [Headbutt]
+    - [Bounce]
+    - [Hydro Pump]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/459_Snover.yaml
+++ b/Prima/459_Snover.yaml
@@ -1,0 +1,18 @@
+species: Snover
+setname: Prima
+item: [null]
+ability: [Snow Warning]
+moves:
+    - [GrassWhistle]
+    - [Sheer Cold]
+    - [Blizzard]
+    - [Leech Seed]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/460_Abomasnow.yaml
+++ b/Prima/460_Abomasnow.yaml
@@ -1,0 +1,18 @@
+species: Abomasnow
+setname: Prima
+item: [null]
+ability: [Snow Warning]
+moves:
+    - [Wood Hammer]
+    - [GrassWhistle]
+    - [Sheer Cold]
+    - [Blizzard]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/461_Weavile.yaml
+++ b/Prima/461_Weavile.yaml
@@ -1,0 +1,18 @@
+species: Weavile
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Dark Pulse]
+    - [Shadow Ball]
+    - [Hyper Beam]
+    - [Blizzard]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/462_Magnezone.yaml
+++ b/Prima/462_Magnezone.yaml
@@ -1,0 +1,18 @@
+species: Magnezone
+setname: Prima
+item: [null]
+ability: [Magnet Pull,Sturdy]
+moves:
+    - [Gyro Ball]
+    - [SonicBoom]
+    - [Zap Cannon]
+    - [Flash Cannon]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/463_Lickilicky.yaml
+++ b/Prima/463_Lickilicky.yaml
@@ -1,0 +1,18 @@
+species: Lickilicky
+setname: Prima
+item: [null]
+ability: [Own Tempo,Oblivious]
+moves:
+    - [Brick Break]
+    - [Lick]
+    - [Slam]
+    - [Power Whip]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/464_Rhyperior.yaml
+++ b/Prima/464_Rhyperior.yaml
@@ -1,0 +1,18 @@
+species: Rhyperior
+setname: Prima
+item: [null]
+ability: [Lightningrod,Rock Head]
+moves:
+    - [Rock Wrecker]
+    - [Stone Edge]
+    - [Poison Jab]
+    - [Mega Horn]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/465_Tangrowth.yaml
+++ b/Prima/465_Tangrowth.yaml
@@ -1,0 +1,18 @@
+species: Tangrowth
+setname: Prima
+item: [null]
+ability: [Chlorophyll,Leaf Guard]
+moves:
+    - [Giga Drain]
+    - [Slam]
+    - [Ingrain]
+    - [Power Whip]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/466_Electivire.yaml
+++ b/Prima/466_Electivire.yaml
@@ -1,0 +1,18 @@
+species: Electivire
+setname: Prima
+item: [null]
+ability: [Motor Drive]
+moves:
+    - [Thunder]
+    - [Giga Impact]
+    - [Quick Attack]
+    - [Discharge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/467_Magmortar.yaml
+++ b/Prima/467_Magmortar.yaml
@@ -1,0 +1,18 @@
+species: Magmortar
+setname: Prima
+item: [null]
+ability: [Flame Body]
+moves:
+    - [Flamethrower]
+    - [Fire Blast]
+    - [Sunny Day]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/468_Togekiss.yaml
+++ b/Prima/468_Togekiss.yaml
@@ -1,0 +1,18 @@
+species: Togekiss
+setname: Prima
+item: [null]
+ability: [Hustle,Serene Grace]
+moves:
+    - [Air Slash]
+    - [Giga Impact]
+    - [Sky Attack]
+    - [ExtremeSpeed]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/469_Yanmega.yaml
+++ b/Prima/469_Yanmega.yaml
@@ -1,0 +1,18 @@
+species: Yanmega
+setname: Prima
+item: [null]
+ability: [Speed Boost,Compoundeyes]
+moves:
+    - [Air Slash]
+    - [AncientPower]
+    - [Roost]
+    - [Bug Buzz]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/470_Leafeon.yaml
+++ b/Prima/470_Leafeon.yaml
@@ -1,0 +1,18 @@
+species: Leafeon
+setname: Prima
+item: [null]
+ability: [Leaf Guard]
+moves:
+    - [GrassWhistle]
+    - [SolarBeam]
+    - [Sunny Day]
+    - [Leaf Blade]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/471_Glaceon.yaml
+++ b/Prima/471_Glaceon.yaml
@@ -1,0 +1,18 @@
+species: Glaceon
+setname: Prima
+item: [null]
+ability: [Snow Cloak]
+moves:
+    - [Hail]
+    - [Last Resort]
+    - [Hyper Beam]
+    - [Blizzard]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/472_Gliscor.yaml
+++ b/Prima/472_Gliscor.yaml
@@ -1,0 +1,18 @@
+species: Gliscor
+setname: Prima
+item: [null]
+ability: [Hyper Cutter,Sand veil]
+moves:
+    - [Defog]
+    - [Earthquake]
+    - [Poison Jab]
+    - [Guillotine]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/473_Mamoswine.yaml
+++ b/Prima/473_Mamoswine.yaml
@@ -1,0 +1,18 @@
+species: Mamoswine
+setname: Prima
+item: [null]
+ability: [Oblivious,Snow Cloak]
+moves:
+    - [Powder Snow]
+    - [Earthquake]
+    - [Hyper Beam]
+    - [Blizzard]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/474_Porygon-Z.yaml
+++ b/Prima/474_Porygon-Z.yaml
@@ -1,0 +1,18 @@
+species: Porygon-Z
+setname: Prima
+item: [null]
+ability: [Adaptability,Download]
+moves:
+    - [Recover]
+    - [Conversion 2]
+    - [Zap Cannon]
+    - [Hyper Beam]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/475_Gallade.yaml
+++ b/Prima/475_Gallade.yaml
@@ -1,0 +1,18 @@
+species: Gallade
+setname: Prima
+item: [null]
+ability: [Steadfast]
+moves:
+    - [Close Combat]
+    - [Focus Punch]
+    - [Psychic]
+    - [Leaf Blade]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/476_Probopass.yaml
+++ b/Prima/476_Probopass.yaml
@@ -1,0 +1,18 @@
+species: Probopass
+setname: Prima
+item: [null]
+ability: [Sturdy,Magnet Pull]
+moves:
+    - [Stone Edge]
+    - [Earth Power]
+    - [Magnet Bomb]
+    - [Flash Cannon]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/477_Dusknoir.yaml
+++ b/Prima/477_Dusknoir.yaml
@@ -1,0 +1,18 @@
+species: Dusknoir
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Shadow Punch]
+    - [Curse]
+    - [Hyper Beam]
+    - [Future Sight]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/478_Froslass.yaml
+++ b/Prima/478_Froslass.yaml
@@ -1,0 +1,18 @@
+species: Froslass
+setname: Prima
+item: [null]
+ability: [Snow Cloak]
+moves:
+    - [Hail]
+    - [Blizzard]
+    - [Destiny Bond]
+    - [Wake-Up Slap]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/479_Rotom.yaml
+++ b/Prima/479_Rotom.yaml
@@ -1,0 +1,18 @@
+species: Rotom
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Ominous Wind]
+    - [Thunder]
+    - [Shadow Ball]
+    - [Charge]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/480_Uxie.yaml
+++ b/Prima/480_Uxie.yaml
@@ -1,0 +1,18 @@
+species: Uxie
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Flail]
+    - [Extrasensory]
+    - [Rest]
+    - [Future Sight]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/481_Mesprit.yaml
+++ b/Prima/481_Mesprit.yaml
@@ -1,0 +1,18 @@
+species: Mesprit
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Healing Wish]
+    - [Extrasensory]
+    - [Rest]
+    - [Future Sight]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/482_Azelf.yaml
+++ b/Prima/482_Azelf.yaml
@@ -1,0 +1,18 @@
+species: Azelf
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Explosion]
+    - [Last Resort]
+    - [Rest]
+    - [Future Sight]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/483_Dialga.yaml
+++ b/Prima/483_Dialga.yaml
@@ -1,0 +1,18 @@
+species: Dialga
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Roar of Time]
+    - [Dragon Claw]
+    - [Flash Cannon]
+    - [Draco Meteor]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/484_Palkia.yaml
+++ b/Prima/484_Palkia.yaml
@@ -1,0 +1,18 @@
+species: Palkia
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Aqua Tail]
+    - [Spacial Rend]
+    - [Dragon Claw]
+    - [Draco Meteor]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/485_Heatran.yaml
+++ b/Prima/485_Heatran.yaml
@@ -1,0 +1,18 @@
+species: Heatran
+setname: Prima
+item: [null]
+ability: [Flash Fire]
+moves:
+    - [Iron Head]
+    - [AncientPower]
+    - [Fire Spin]
+    - [Magma Storm]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/486_Regigigas.yaml
+++ b/Prima/486_Regigigas.yaml
@@ -1,0 +1,18 @@
+species: Regigigas
+setname: Prima
+item: [null]
+ability: [Slow Start]
+moves:
+    - [Giga Impact]
+    - [SuperPower]
+    - [Fire Punch]
+    - [Mega Punch]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/487_Giratina.yaml
+++ b/Prima/487_Giratina.yaml
@@ -1,0 +1,18 @@
+species: Giratina
+setname: Prima
+item: [null]
+ability: [Pressure]
+moves:
+    - [Shadow Claw]
+    - [Shadow Force]
+    - [Dragon Claw]
+    - [Draco Meteor]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/488_Cresselia.yaml
+++ b/Prima/488_Cresselia.yaml
@@ -1,0 +1,18 @@
+species: Cresselia
+setname: Prima
+item: [null]
+ability: [Levitate]
+moves:
+    - [Psychic]
+    - [Moonlight]
+    - [Hyper Beam]
+    - [Lunar Dance]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/489_Phione.yaml
+++ b/Prima/489_Phione.yaml
@@ -1,0 +1,18 @@
+species: Phione
+setname: Prima
+item: [null]
+ability: [Hydration]
+moves:
+    - [Aqua Ring]
+    - [Rain Dance]
+    - [Dive]
+    - [Surf]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]

--- a/Prima/490_Manaphy.yaml
+++ b/Prima/490_Manaphy.yaml
@@ -1,0 +1,18 @@
+species: Manaphy
+setname: Prima
+item: [null]
+ability: [Hydration]
+moves:
+    - [Aqua Ring]
+    - [Rain Dance]
+    - [Giga Impact]
+    - [Dive]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 0.0
+ball: [Premier]
+nature: Serious
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 85, atk: 85, def: 85, spA: 85, spD: 85, spe: 85}
+tags: [prima]


### PR DESCRIPTION
Sets were taken directly from [this sheet compiled by PokemonGod777](https://docs.google.com/spreadsheets/d/1VG_IMdV8n2PnfXAbStS-opqP3FB-ljLuGJxmR1urMs8/edit#gid=0) and the YAMLs were generated from [this Python script](https://gist.github.com/mathfreak231/f2877a8ec9f9efd394aa1259d7bec7b7). All typos were preserved except Leafeon's Leaf Guard move (corrected to Leaf Blade) and Hitmonlee's Round Kick move (corrected to Rolling Kick), both changed because they did not match closely enough and errored Pokecat.

All sets have generic EVs, IVs, and genders, which can be fixed later.