### PR TITLE
Test Your Luck runmons

### DIFF
--- a/pokesets/1 XM_Standard/XM_Exeggcute.yaml
+++ b/pokesets/1 XM_Standard/XM_Exeggcute.yaml
@@ -1,15 +1,15 @@
 species: Exeggcute
 ingamename: Falinks
 displayname: Falinks
-setname: Costume
-tags: [costume]
+setname: Christmas
+tags: [christmas]
 item: [Liechi Berry]
 ability: [Battle Armor]
 moves:
     - [Close Combat]
-    - [Bulk Up]
     - [Megahorn]
     - [Counter]
+    - [Defend Order]
 gender: [m, f]
 happiness: 255
 biddable: True
@@ -19,5 +19,4 @@ shiny: True
 nature: Naughty
 ivs: 31
 evs: {hp: 50, atk: 140, def: 0, spA: 0, spD: 0, spe: 0}
-level: 5
 hidden: false

--- a/pokesets/Costume/174_Togepi.yaml
+++ b/pokesets/Costume/174_Togepi.yaml
@@ -1,0 +1,23 @@
+species: Togepi
+ingamename: Toxel
+displayname: Toxel
+setname: Costume
+tags: [costume]
+item: [Poison Barb]
+ability: [Static]
+moves:
+    - [Poison Jab]
+    - [Discharge]
+    - [Swagger]
+    - [Encore]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 1.0
+ball: [Luxury]
+shiny: True
+nature: Modest
+ivs: {hp: 31, atk: 31, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 240, atk: 0, def: 56, spA: 156, spD: 56, spe: 0}
+level: 5
+hidden: false

--- a/pokesets/Runmon/TestYourLuck.yaml
+++ b/pokesets/Runmon/TestYourLuck.yaml
@@ -1,0 +1,56 @@
+species: Miltank
+ingamename: Milkshake
+displayname: Milkshake
+setname: TPP Sword - Test your Luck
+tags: [runmon, in-game]
+item: [Choice Scarf]
+ability: [Scrappy]
+moves:
+    - [Metronome]
+gender: [f]
+happiness: 255
+biddable: True
+rarity: 1.0
+ball: [Poké]
+shiny: False
+nature: Sassy
+ivs: {hp: 30, atk: 31, def: 13, spA: 28, spD: 1, spe: 10}
+evs: {hp: 252, atk: 0, def: 40, spA: 0, spD: 200, spe: 18}
+---
+species: Sableye
+ingamename: "Chaos "
+displayname: "Chaos "
+setname: TPP Sword - Test your Luck
+tags: [runmon, in-game]
+item: [Starf Berry]
+ability: [Keen Eye]
+moves:
+    - [Metronome]
+happiness: 255
+gender: [f]
+biddable: True
+rarity: 1.0
+ball: [Poké]
+shiny: False
+nature: Modest
+ivs: {hp: 31, atk: 13, def: 12, spA: 22, spD: 25, spe: 15}
+evs: {hp: 0, atk: 6, def: 2, spA: 252, spD: 0, spe: 250}
+# ---
+# species: Grimmsnarl
+# ingamename: Shrek
+# displayname: Shrek
+# setname: TPP Sword - Test your Luck
+# tags: [runmon, in-game]
+# item: [Safety Goggles]
+# ability: [Prankster]
+# moves:
+#     - [Metronome]
+# gender: [m]
+# happiness: 255
+# biddable: True
+# rarity: 1.0
+# ball: [Poké]
+# shiny: False
+# nature: Brave
+# ivs: {hp: 11, atk: 21, def: 19, spA: 17, spD: 9, spe: 7}
+# evs: {hp: 100, atk: 252, def: 2, spA: 0, spD: 156, spe: 0}

--- a/pokesets/Runmon/TestYourLuck.yaml
+++ b/pokesets/Runmon/TestYourLuck.yaml
@@ -1,7 +1,7 @@
 species: Miltank
 ingamename: Milkshake
 displayname: Milkshake
-setname: TPP Sword - Test your Luck
+setname: TPP Sword - Test Your Luck
 tags: [runmon, in-game]
 item: [Choice Scarf]
 ability: [Scrappy]
@@ -14,13 +14,13 @@ rarity: 1.0
 ball: [Poké]
 shiny: False
 nature: Sassy
-ivs: {hp: 30, atk: 31, def: 13, spA: 28, spD: 1, spe: 10}
+ivs: 31 # {hp: 30, atk: 31, def: 13, spA: 28, spD: 1, spe: 10}
 evs: {hp: 252, atk: 0, def: 40, spA: 0, spD: 200, spe: 18}
 ---
 species: Sableye
 ingamename: "Chaos "
 displayname: "Chaos "
-setname: TPP Sword - Test your Luck
+setname: TPP Sword - Test Your Luck
 tags: [runmon, in-game]
 item: [Starf Berry]
 ability: [Keen Eye]
@@ -33,13 +33,13 @@ rarity: 1.0
 ball: [Poké]
 shiny: False
 nature: Modest
-ivs: {hp: 31, atk: 13, def: 12, spA: 22, spD: 25, spe: 15}
+ivs: 31 # {hp: 31, atk: 13, def: 12, spA: 22, spD: 25, spe: 15}
 evs: {hp: 0, atk: 6, def: 2, spA: 252, spD: 0, spe: 250}
 # ---
 # species: Grimmsnarl
 # ingamename: Shrek
 # displayname: Shrek
-# setname: TPP Sword - Test your Luck
+# setname: TPP Sword - Test Your Luck
 # tags: [runmon, in-game]
 # item: [Safety Goggles]
 # ability: [Prankster]
@@ -52,5 +52,5 @@ evs: {hp: 0, atk: 6, def: 2, spA: 252, spD: 0, spe: 250}
 # ball: [Poké]
 # shiny: False
 # nature: Brave
-# ivs: {hp: 11, atk: 21, def: 19, spA: 17, spD: 9, spe: 7}
+# ivs: 31 # {hp: 11, atk: 21, def: 19, spA: 17, spD: 9, spe: 7}
 # evs: {hp: 100, atk: 252, def: 2, spA: 0, spD: 156, spe: 0}


### PR DESCRIPTION
Added both of them with the info M4 provided. Put them in their own file for now, although if it makes better sense I can always move them to the Sword runmons. I added Grimmsnarl just because the data was already there, but commented him out in the offchance PBR ever mods him in.

Only other change was made to costumes - after some thinking, I moved the Falinks set to Xmas because it's a single-stage Pokemon and doesn't really fit the format like the Galar starters or Kubfu. Added a new Costume mon as a replacement.

Let me know if anything else should be added in. I can always add the runmons sets for Rando Black, Black2, and Blazing Emerald, but I don't know if the moveset team approves of the adjustments I had to make for non-PBR moves and abilities. And I don't have the stats for the runmons afterwards, so I can't do those. 