### PR TITLE
Add additional movesets for pokemon that only have one

### DIFF
--- a/pokesets/1 HW_Standard/HW_Altaria.yaml
+++ b/pokesets/1 HW_Standard/HW_Altaria.yaml
@@ -1,0 +1,22 @@
+species: Altaria
+ingamename: WeathWitch
+displayname: Weather Witch
+setname: Halloween
+tags: [halloween]
+item: [Damp Rock, Heat Rock, Icy Rock, Smooth Rock]
+ability: [Drizzle, Drought]
+moves:
+    - [Weather Ball]
+    - [Secret Power]
+    - [Nature Power]
+    - [Sandstorm, Hail]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 1.0
+ball: [Ultra]
+shiny: True
+nature: Modest
+ivs: {hp: 31, atk: 0, def: 31, spA: 31, spD: 31, spe: 31}
+evs: {hp: 64, atk: 0, def: 64, spA: 252, spD: 64, spe: 64}
+hidden: false

--- a/pokesets/1 Standard/010_Caterpie.yaml
+++ b/pokesets/1 Standard/010_Caterpie.yaml
@@ -11,8 +11,27 @@ moves:
 gender: [m, f]
 happiness: 255
 biddable: True
-rarity: 1.0
+rarity: .95
 ball: [Net]
 nature: Jolly
 evs: {hp: 164, atk: 48, def: 48, spA: 0, spD: 212, spe: 36}
+ivs: 31
+---
+species: Caterpie
+setname: Physical
+tags: [standard]
+item: [Chesto Berry]
+ability: [Shield Dust]
+moves:
+    - [U-turn]
+    - [Megahorn]
+    - [Sleep Talk, Snore]
+    - [Rest]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: .05
+ball: [Net]
+nature: Lonely
+evs: {hp: 164, atk: 158, def: 48, spA: 0, spD: 92, spe: 46}
 ivs: 31

--- a/pokesets/1 Standard/013_Weedle.yaml
+++ b/pokesets/1 Standard/013_Weedle.yaml
@@ -16,3 +16,22 @@ ball: [Net]
 nature: Jolly
 evs: {hp: 4, atk: 252, def: 0, spA: 0, spD: 0, spe: 252}
 ivs: 31
+---
+species: Weedle
+setname: Physical
+tags: [standard]
+item: [Poison Barb]
+ability: [Mold Breaker]
+moves:
+    - [Mega Horn]
+    - [Dig]
+    - [Poison Jab]
+    - [Heal Order]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 1.0
+ball: [Net]
+nature: Jolly
+evs: {hp: 4, atk: 252, def: 0, spA: 0, spD: 0, spe: 252}
+ivs: 31

--- a/pokesets/1 Standard/021_Spearow.yaml
+++ b/pokesets/1 Standard/021_Spearow.yaml
@@ -11,7 +11,7 @@ moves:
 gender: [m, f]
 happiness: 255
 biddable: True
-rarity: 1.0
+rarity: .75
 ball: [Nest]
 nature: Adamant
 evs: {hp: 4, atk: 252, def: 0, spA: 0, spD: 0, spe: 252}
@@ -30,7 +30,7 @@ moves:
 gender: [m, f]
 happiness: 255
 biddable: True
-rarity: 1.0
+rarity: .25
 ball: [Nest]
 nature: Modest
 evs: {hp: 4, atk: 0, def: 0, spA: 252, spD: 0, spe: 252}

--- a/pokesets/1 Standard/021_Spearow.yaml
+++ b/pokesets/1 Standard/021_Spearow.yaml
@@ -16,3 +16,22 @@ ball: [Nest]
 nature: Adamant
 evs: {hp: 4, atk: 252, def: 0, spA: 0, spD: 0, spe: 252}
 ivs: 31
+---
+species: Spearow
+setname: Special
+tags: [standard]
+item: [Power Herb]
+ability: [Sniper]
+moves:
+    - [Air Slash]
+    - [Chatter]
+    - [Razor Wind]
+    - [Feather Dance]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: 1.0
+ball: [Nest]
+nature: Modest
+evs: {hp: 4, atk: 0, def: 0, spA: 252, spD: 0, spe: 252}
+ivs: 31

--- a/pokesets/1 Standard/132_Ditto.yaml
+++ b/pokesets/1 Standard/132_Ditto.yaml
@@ -7,8 +7,26 @@ moves:
     - [Transform]
 happiness: 128
 biddable: True
-rarity: 1.0
+rarity: .95
 ball: [Repeat]
 nature: Timid
 evs: {hp: 252, atk: 0, def: 4, spA: 0, spD: 0, spe: 252}
 ivs: {hp: 31, atk: 30, def: 31, spA: 30, spD: 31, spe: 30}
+---
+species: Ditto
+setname: Rage Glitch
+tags: [standard]
+item: [Metal Powder]
+ability: [Limber]
+moves:
+    - [Fly]
+    - [Dragon Claw]
+    - [Rage]
+    - [Protect]
+happiness: 128
+biddable: True
+rarity: .05
+ball: [Premier]
+nature: Adamant
+evs: {hp: 150, atk: 152, def: 53, spA: 0, spD: 53, spe: 100}
+ivs: {hp: 31, atk: 31, def: 30, spA: 30, spD: 31, spe: 30}

--- a/pokesets/1 Standard/161_Sentret.yaml
+++ b/pokesets/1 Standard/161_Sentret.yaml
@@ -21,7 +21,7 @@ species: Sentret
 setname: Random
 tags: [standard]
 item: [Lum Berry]
-ability: [Download]
+ability: [Download, Clear Body]
 moves:
     - [Metronome]
     - [Assist]

--- a/pokesets/1 Standard/161_Sentret.yaml
+++ b/pokesets/1 Standard/161_Sentret.yaml
@@ -11,8 +11,27 @@ moves:
 gender: [m, f]
 happiness: 255
 biddable: True
-rarity: 1.0
+rarity: .75
 ball: [Repeat]
 nature: Adamant
 ivs: 31
 evs: {hp: 148, atk: 252, def: 16, spA: 0, spD: 0, spe: 92}
+---
+species: Sentret
+setname: Random
+tags: [standard]
+item: [Lum Berry]
+ability: [Download]
+moves:
+    - [Metronome]
+    - [Assist]
+    - [Sleep Talk]
+    - [Acupressure]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: .25
+ball: [Luxury]
+nature: Hardy
+ivs: 31
+evs: {hp: 148, atk: 126, def: 8, spA: 126, spD: 8, spe: 92}

--- a/pokesets/1 Standard/165_Ledyba.yaml
+++ b/pokesets/1 Standard/165_Ledyba.yaml
@@ -11,8 +11,27 @@ moves:
 gender: [m, f]
 happiness: 255
 biddable: True
-rarity: 1.0
+rarity: .75
 ball: [Nest]
 nature: Modest
 ivs: {hp: 31, atk: 2, def: 31, spA: 30, spD: 31, spe: 30}
 evs: {hp: 156, atk: 0, def: 40, spA: 252, spD: 0, spe: 60}
+---
+species: Ledyba
+setname: Physical
+tags: [standard]
+item: [Salac Berry]
+ability: [Swarm]
+moves:
+    - [Attack Order]
+    - [Fly, Bounce]
+    - [Agility, Defend Order]
+    - [Baton Pass]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: .25
+ball: [Nest]
+nature: Adamant
+ivs: {hp: 31, atk: 2, def: 31, spA: 30, spD: 31, spe: 30}
+evs: {hp: 156, atk: 252, def: 40, spA: 0, spD: 0, spe: 60}

--- a/pokesets/1 Standard/236_Tyrogue.yaml
+++ b/pokesets/1 Standard/236_Tyrogue.yaml
@@ -11,8 +11,27 @@ moves:
 gender: [m]
 happiness: 255
 biddable: True
-rarity: 1.0
+rarity: .75
 ball: [Poké]
 nature: Adamant
 ivs: 31
 evs: {hp: 128, atk: 252, def: 64, spA: 0, spD: 64, spe: 0}
+---
+species: Tyrogue
+setname: Special
+tags: [standard]
+item: [Expert Belt]
+ability: [Vital Spirit]
+moves:
+    - [Fake Out]
+    - [Aura Sphere]
+    - [Vacuum Wave]
+    - [Dark Pulse]
+gender: [m,f]
+happiness: 255
+biddable: True
+rarity: .25
+ball: [Poké]
+nature: Modest
+ivs: 31
+evs: {hp: 128, atk: 0, def: 64, spA: 252, spD: 64, spe: 0}

--- a/pokesets/1 Standard/238_Smoochum.yaml
+++ b/pokesets/1 Standard/238_Smoochum.yaml
@@ -11,8 +11,27 @@ moves:
 gender: [m, f]
 happiness: 255
 biddable: True
-rarity: 1.0
+rarity: .9
 ball: [Premier]
 nature: Timid
 ivs: 31
 evs: {hp: 152, atk: 0, def: 0, spA: 48, spD: 56, spe: 252}
+---
+species: Smoochum
+setname: Sacrifice
+tags: [standard]
+item: [Focus Sash]
+ability: [Oblivious]
+moves:
+    - [Explosion]
+    - [Sing]
+    - [Perish Song]
+    - [Mean Look]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: .1
+ball: [Great]
+nature: Modest
+ivs: 31
+evs: {hp: 4, atk: 0, def:0 , spA: 252, spD: 0, spe: 252}

--- a/pokesets/1 Standard/238_Smoochum.yaml
+++ b/pokesets/1 Standard/238_Smoochum.yaml
@@ -34,4 +34,4 @@ rarity: .1
 ball: [Great]
 nature: Modest
 ivs: 31
-evs: {hp: 4, atk: 0, def:0 , spA: 252, spD: 0, spe: 252}
+evs: {hp: 4, atk: 0, def: 0, spA: 252, spD: 0, spe: 252}

--- a/pokesets/1 Standard/309_Electrike.yaml
+++ b/pokesets/1 Standard/309_Electrike.yaml
@@ -11,8 +11,27 @@ moves:
 gender: [m, f]
 happiness: 255
 biddable: True
-rarity: 1.0
+rarity: .6
 ball: [Premier]
 nature: Timid
 ivs: {hp: 31, atk: 2, def: 30, spA: 30, spD: 31, spe: 31}
 evs: {hp: 84, atk: 0, def: 0, spA: 252, spD: 0, spe: 172}
+---
+species: Electrike
+setname: Physical
+tags: [standard]
+item: [Null]
+ability: [Static]
+moves:
+    - [Thunder Fang]
+    - [Return]
+    - [Fire Fang]
+    - [Howl]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: .4
+ball: [Premier]
+nature: Timid
+ivs: {hp: 31, atk: 31, def: 30, spA: 1, spD: 31, spe: 31}
+evs: {hp: 84, atk: 252, def: 0, spA: 0, spD: 0, spe: 172}

--- a/pokesets/1 Standard/325_Spoink.yaml
+++ b/pokesets/1 Standard/325_Spoink.yaml
@@ -11,8 +11,27 @@ moves:
 gender: [m, f]
 happiness: 255
 biddable: True
-rarity: 1.0
+rarity: .75
 ball: [Luxury]
 nature: Modest
 ivs: {hp: 31, atk: 0, def: 31, spA: 31, spD: 31, spe: 31}
 evs: {hp: 36, atk: 0, def: 108, spA: 164, spD: 0, spe: 200}
+---
+species: Spoink
+setname: Physical
+tags: [standard]
+item: [Null]
+ability: [Own Tempo]
+moves:
+    - [Bounce]
+    - [Body Slam]
+    - [Zen Headbutt]
+    - [Reflect]
+gender: [m, f]
+happiness: 255
+biddable: True
+rarity: .25
+ball: [Luxury]
+nature: Adamant
+ivs: {hp: 31, atk: 31, def: 31, spA: 0, spD: 31, spe: 31}
+evs: {hp: 36, atk: 164, def: 108, spA: 0, spD: 0, spe: 200}


### PR DESCRIPTION
I went through all the pokemon to identify which only had one moveset. For all of them (except Wynaut) I added a secondary moveset. These might not be the most Smogon-approved perfect movesets, but I don't think they'll upset game balance at all. For most of these Pokemon, they only had one Physical or Special based moveset , so I just added one they didn't have. The Sentret one is a bit of a joke, but I also think it could be fun. The Ditto one is one that is technically possible due to a glitch, and allows for it's other signature item to be used. All the others are movesets not too different from other Pokemon in this repository. The only one I couldn't think of an alternate for was Wynaut.