### PR TITLE
Removing useless item from adv corphish

### DIFF
--- a/pokesets/advanced/341_Corphish.yaml
+++ b/pokesets/advanced/341_Corphish.yaml
@@ -22,7 +22,7 @@ evs: {hp: 85, atk: 85, def: 85, spA: 0, spD: 85, spe: 170}
 species: Corphish
 setname: a-Special
 tags: [advanced]
-item: [Berry Juice, Soft Sand, Salac Berry]
+item: [Berry Juice, Salac Berry]
 ability: [Adaptability]
 moves:
     - [Bubblebeam, Water Pulse]


### PR DESCRIPTION
Removing useless or unused item from the advanced Corphish special set from when it was originally created. Likely a bad copy-paste. 